### PR TITLE
feature: 为产品加入单独审批功能

### DIFF
--- a/portal-dal/src/main/java/com/alibaba/apiopenplatform/entity/Product.java
+++ b/portal-dal/src/main/java/com/alibaba/apiopenplatform/entity/Product.java
@@ -73,4 +73,7 @@ public class Product extends BaseEntity {
     @Column(name = "status", length = 64)
     @Enumerated(EnumType.STRING)
     private ProductStatus status = ProductStatus.PENDING;
+
+    @Column(name = "auto_approve")
+    private Boolean autoApprove;
 }

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/controller/ConsumerController.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/controller/ConsumerController.java
@@ -21,6 +21,7 @@ package com.alibaba.apiopenplatform.controller;
 
 import com.alibaba.apiopenplatform.core.annotation.AdminAuth;
 import com.alibaba.apiopenplatform.core.annotation.DeveloperAuth;
+import com.alibaba.apiopenplatform.core.annotation.AdminOrDeveloperAuth;
 import com.alibaba.apiopenplatform.dto.params.consumer.CreateCredentialParam;
 import com.alibaba.apiopenplatform.dto.params.consumer.QueryConsumerParam;
 import com.alibaba.apiopenplatform.dto.params.consumer.CreateConsumerParam;
@@ -116,7 +117,7 @@ public class ConsumerController {
 
     @Operation(summary = "获取Consumer的订阅列表")
     @GetMapping("/{consumerId}/subscriptions")
-    @DeveloperAuth
+    @AdminOrDeveloperAuth
     public PageResult<SubscriptionResult> listSubscriptions(@PathVariable String consumerId,
                                                             QuerySubscriptionParam param,
                                                             Pageable pageable) {

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/core/annotation/AdminOrDeveloperAuth.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/core/annotation/AdminOrDeveloperAuth.java
@@ -17,33 +17,17 @@
  * under the License.
  */
 
-package com.alibaba.apiopenplatform.dto.params.product;
+package com.alibaba.apiopenplatform.core.annotation;
 
-import com.alibaba.apiopenplatform.dto.converter.InputConverter;
-import com.alibaba.apiopenplatform.entity.Product;
-import com.alibaba.apiopenplatform.support.enums.ProductType;
-import com.alibaba.apiopenplatform.support.product.ProductIcon;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import org.springframework.security.access.prepost.PreAuthorize;
 
-import javax.validation.constraints.NotBlank;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-@Data
-public class UpdateProductParam implements InputConverter<Product> {
-
-    private String name;
-
-    private String description;
-
-    private ProductType type;
-
-    private Boolean enableConsumerAuth;
-
-    private String document;
-
-    private ProductIcon icon;
-
-    private String category;
-
-    private Boolean autoApprove;
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('ADMIN') or hasRole('DEVELOPER')")
+public @interface AdminOrDeveloperAuth {
 }

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/dto/params/product/CreateProductParam.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/dto/params/product/CreateProductParam.java
@@ -48,4 +48,6 @@ public class CreateProductParam implements InputConverter<Product> {
     private ProductIcon icon;
 
     private String category;
+
+    private Boolean autoApprove;
 }

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/dto/result/ProductResult.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/dto/result/ProductResult.java
@@ -48,6 +48,8 @@ public class ProductResult implements OutputConverter<ProductResult, Product> {
 
     private String category;
 
+    private Boolean autoApprove;
+
     private LocalDateTime createAt;
 
     private LocalDateTime updatedAt;

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/impl/ConsumerServiceImpl.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/impl/ConsumerServiceImpl.java
@@ -240,11 +240,22 @@ public class ConsumerServiceImpl implements ConsumerService {
         ProductSubscription subscription = param.convertTo();
         subscription.setConsumerId(consumerId);
         
-        // 检查autoApprove设置
-        PortalResult portal = portalService.getPortal(consumer.getPortalId());
-        log.info("portal: {}", JSONUtil.toJsonStr(portal));
-        boolean autoApprove = portal.getPortalSettingConfig() != null
-                && BooleanUtil.isTrue(portal.getPortalSettingConfig().getAutoApproveSubscriptions());
+        // 检查产品级别的自动审批设置
+        boolean autoApprove = false;
+        
+        // 优先检查产品级别的autoApprove配置
+        if (product.getAutoApprove() != null) {
+            // 如果产品配置了autoApprove，直接使用产品级别的配置
+            autoApprove = product.getAutoApprove();
+            log.info("使用产品级别自动审批配置: productId={}, autoApprove={}", param.getProductId(), autoApprove);
+        } else {
+            // 如果产品未配置autoApprove，则使用平台级别的配置
+            PortalResult portal = portalService.getPortal(consumer.getPortalId());
+            log.info("portal: {}", JSONUtil.toJsonStr(portal));
+            autoApprove = portal.getPortalSettingConfig() != null
+                    && BooleanUtil.isTrue(portal.getPortalSettingConfig().getAutoApproveSubscriptions());
+            log.info("使用平台级别自动审批配置: portalId={}, autoApprove={}", consumer.getPortalId(), autoApprove);
+        }
         
         if (autoApprove) {
             // 如果autoApprove为true，立即授权并设置为APPROVED状态

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/impl/ProductServiceImpl.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/impl/ProductServiceImpl.java
@@ -95,6 +95,12 @@ public class ProductServiceImpl implements ProductService {
         Product product = param.convertTo();
         product.setProductId(productId);
         product.setAdminId(contextHolder.getUser());
+        
+        // 设置默认的自动审批配置，如果未指定则默认为null（使用平台级别配置）
+        if (param.getAutoApprove() != null) {
+            product.setAutoApprove(param.getAutoApprove());
+        }
+        
         productRepository.save(product);
 
         return getProduct(productId);
@@ -143,6 +149,9 @@ public class ProductServiceImpl implements ProductService {
 
         // Consumer鉴权配置同步至网关
         Optional.ofNullable(param.getEnableConsumerAuth()).ifPresent(product::setEnableConsumerAuth);
+        
+        // 更新自动审批配置
+        Optional.ofNullable(param.getAutoApprove()).ifPresent(product::setAutoApprove);
 
         productRepository.saveAndFlush(product);
         return getProduct(product.getProductId());

--- a/portal-web/api-portal-admin/src/components/api-product/ApiProductFormModal.tsx
+++ b/portal-web/api-portal-admin/src/components/api-product/ApiProductFormModal.tsx
@@ -205,6 +205,17 @@ export default function ApiProductFormModal({
           </Select>
         </Form.Item>
 
+        <Form.Item
+          label="自动审批订阅"
+          name="autoApprove"
+          tooltip="启用后，该产品的订阅申请将自动审批通过，无需管理员手动审批。留空则使用平台级别的自动审批设置。"
+        >
+          <Select placeholder="请选择自动审批设置" allowClear>
+            <Select.Option value={true}>启用</Select.Option>
+            <Select.Option value={false}>禁用</Select.Option>
+          </Select>
+        </Form.Item>
+
         <Form.Item label="上传头像" name="icon">
           <Upload
             listType="picture-card"

--- a/portal-web/api-portal-admin/src/components/api-product/ApiProductOverview.tsx
+++ b/portal-web/api-portal-admin/src/components/api-product/ApiProductOverview.tsx
@@ -119,6 +119,18 @@ export function ApiProductOverview({ apiProduct }: ApiProductOverviewProps) {
                 <span className="text-gray-600">产品描述</span>
                 <span>{apiProduct.description}</span>
               </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600">自动审批订阅</span>
+                <span>
+                  {apiProduct.autoApprove === true ? (
+                    <Tag color="green">启用</Tag>
+                  ) : apiProduct.autoApprove === false ? (
+                    <Tag color="red">禁用</Tag>
+                  ) : (
+                    <Tag color="default">使用平台设置</Tag>
+                  )}
+                </span>
+              </div>
               
             </div>
           </Card>

--- a/portal-web/api-portal-admin/src/components/portal/PortalDevelopers.tsx
+++ b/portal-web/api-portal-admin/src/components/portal/PortalDevelopers.tsx
@@ -1,9 +1,10 @@
 import { Card, Table, Badge, Button, Space, Avatar, message, Modal } from 'antd'
-import { EditOutlined, DeleteOutlined, ExclamationCircleOutlined, EyeOutlined } from '@ant-design/icons'
+import { EditOutlined, DeleteOutlined, ExclamationCircleOutlined, EyeOutlined, UnorderedListOutlined } from '@ant-design/icons'
 import { useEffect, useState } from 'react'
 import { Portal, Developer } from '@/types'
 import { portalApi } from '@/lib/api'
 import { formatDateTime } from '@/lib/utils'
+import { SubscriptionListModal } from '@/components/subscription/SubscriptionListModal'
 
 interface PortalDevelopersProps {
   portal: Portal
@@ -42,6 +43,10 @@ export function PortalDevelopers({ portal }: PortalDevelopersProps) {
     showTotal: (total: number, range: [number, number]) => 
       `第 ${range[0]}-${range[1]} 条，共 ${total} 条`
   })
+
+  // 订阅列表相关状态
+  const [subscriptionModalVisible, setSubscriptionModalVisible] = useState(false)
+  const [currentConsumer, setCurrentConsumer] = useState<Consumer | null>(null)
 
   useEffect(() => {
     fetchDevelopers()
@@ -146,13 +151,25 @@ export function PortalDevelopers({ portal }: PortalDevelopersProps) {
     }
   }
 
+  // 查看订阅列表
+  const handleViewSubscriptions = (consumer: Consumer) => {
+    setCurrentConsumer(consumer)
+    setSubscriptionModalVisible(true)
+  }
+
+  // 关闭订阅列表模态框
+  const handleSubscriptionModalCancel = () => {
+    setSubscriptionModalVisible(false)
+    setCurrentConsumer(null)
+  }
+
 
   const columns = [
     {
       title: '开发者名称/ID',
       dataIndex: 'username',
       key: 'username',
-      fixed: 'left',
+      fixed: 'left' as const,
       width: 300,
       render: (username: string, record: Developer) => (
         <div className="ml-2">
@@ -180,7 +197,7 @@ export function PortalDevelopers({ portal }: PortalDevelopersProps) {
     {
       title: '操作',
       key: 'action',
-      fixed: 'right',
+      fixed: 'right' as const,
       width: 300,
       render: (_: any, record: Developer) => (
         <Space size="middle">
@@ -245,20 +262,20 @@ export function PortalDevelopers({ portal }: PortalDevelopersProps) {
       width: 150,
       render: (date: string) => formatDateTime(date)
     },
-    // {
-    //   title: '操作',
-    //   key: 'action',
-    //   width: 120,
-    //   render: (_: any, record: Consumer) => record.status !== 'APPROVED' && (
-    //     <Button 
-    //       onClick={() => handleConsumerStatusUpdate(record.consumerId)} 
-    //       type="link" 
-    //       icon={<EditOutlined />}
-    //     >
-    //       审批
-    //     </Button>
-    //   ),
-    // },
+    {
+      title: '操作',
+      key: 'action',
+      width: 120,
+      render: (_: any, record: Consumer) => (
+        <Button 
+          onClick={() => handleViewSubscriptions(record)} 
+          type="link" 
+          icon={<UnorderedListOutlined />}
+        >
+          订阅列表
+        </Button>
+      ),
+    },
   ]
 
   return (
@@ -311,6 +328,16 @@ export function PortalDevelopers({ portal }: PortalDevelopersProps) {
           scroll={{ y: 'calc(100vh - 400px)' }}
         />
       </Modal>
+
+      {/* 订阅列表弹窗 */}
+      {currentConsumer && (
+        <SubscriptionListModal
+          visible={subscriptionModalVisible}
+          consumerId={currentConsumer.consumerId}
+          consumerName={currentConsumer.name}
+          onCancel={handleSubscriptionModalCancel}
+        />
+      )}
 
     </div>
   )

--- a/portal-web/api-portal-admin/src/components/subscription/SubscriptionListModal.tsx
+++ b/portal-web/api-portal-admin/src/components/subscription/SubscriptionListModal.tsx
@@ -1,0 +1,222 @@
+import { Modal, Table, Badge, message, Button, Popconfirm } from 'antd';
+import { useEffect, useState } from 'react';
+import { Subscription } from '@/types/subscription';
+import { portalApi } from '@/lib/api';
+import { formatDateTime } from '@/lib/utils';
+
+interface SubscriptionListModalProps {
+  visible: boolean;
+  consumerId: string;
+  consumerName: string;
+  onCancel: () => void;
+}
+
+export function SubscriptionListModal({
+  visible,
+  consumerId,
+  consumerName,
+  onCancel
+}: SubscriptionListModalProps) {
+  const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [pagination, setPagination] = useState({
+    current: 1,
+    pageSize: 10,
+    total: 0,
+    showSizeChanger: true,
+    showQuickJumper: true,
+    showTotal: (total: number, range: [number, number]) => 
+      `第 ${range[0]}-${range[1]} 条，共 ${total} 条`
+  });
+
+  useEffect(() => {
+    if (visible && consumerId) {
+      fetchSubscriptions();
+    }
+  }, [visible, consumerId, pagination.current, pagination.pageSize]);
+
+  const fetchSubscriptions = () => {
+    setLoading(true);
+    portalApi.getConsumerSubscriptions(consumerId, {
+      page: pagination.current - 1, // 后端从0开始
+      size: pagination.pageSize
+    }).then((res) => {
+      setSubscriptions(res.data.content || []);
+      setPagination(prev => ({
+        ...prev,
+        total: res.data.totalElements || 0
+      }));
+    }).catch((err) => {
+      console.error('获取订阅列表失败:', err);
+      message.error('获取订阅列表失败');
+    }).finally(() => {
+      setLoading(false);
+    });
+  };
+
+  const handleTableChange = (paginationInfo: any) => {
+    setPagination(prev => ({
+      ...prev,
+      current: paginationInfo.current,
+      pageSize: paginationInfo.pageSize
+    }));
+  };
+
+  const handleApproveSubscription = async (subscription: Subscription) => {
+    setActionLoading(`${subscription.consumerId}-${subscription.productId}-approve`);
+    try {
+      await portalApi.approveSubscription(subscription.consumerId, subscription.productId);
+      message.success('审批通过成功');
+      fetchSubscriptions(); // 重新获取数据
+    } catch (error: any) {
+      console.error('审批失败:', error);
+      const errorMessage = error.response?.data?.message || error.message || '审批失败';
+      message.error(`审批失败: ${errorMessage}`);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleDeleteSubscription = async (subscription: Subscription) => {
+    setActionLoading(`${subscription.consumerId}-${subscription.productId}-delete`);
+    try {
+      await portalApi.deleteSubscription(subscription.consumerId, subscription.productId);
+      message.success('删除订阅成功');
+      fetchSubscriptions(); // 重新获取数据
+    } catch (error: any) {
+      console.error('删除订阅失败:', error);
+      const errorMessage = error.response?.data?.message || error.message || '删除订阅失败';
+      message.error(`删除订阅失败: ${errorMessage}`);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const columns = [
+    {
+      title: '产品名称',
+      dataIndex: 'productName',
+      key: 'productName',
+      render: (productName: string) => (
+        <div>
+          <div className="font-medium">{productName || '未知产品'}</div>
+        </div>
+      )
+    },
+    {
+      title: '产品类型',
+      dataIndex: 'productType',
+      key: 'productType',
+      render: (productType: string) => (
+        <Badge 
+          color={productType === 'REST_API' ? 'blue' : 'purple'} 
+          text={productType === 'REST_API' ? 'REST API' : 'MCP Server'} 
+        />
+      )
+    },
+    {
+      title: '订阅状态',
+      dataIndex: 'status',
+      key: 'status',
+      render: (status: string) => (
+        <Badge 
+          status={status === 'APPROVED' ? 'success' : 'processing'} 
+          text={status === 'APPROVED' ? '已通过' : '待审批'} 
+        />
+      )
+    },
+    {
+      title: '订阅时间',
+      dataIndex: 'createAt',
+      key: 'createAt',
+      render: (date: string) => formatDateTime(date)
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updatedAt',
+      key: 'updatedAt',
+      render: (date: string) => formatDateTime(date)
+    },
+    {
+      title: '操作',
+      key: 'action',
+      width: 120,
+      render: (_: any, record: Subscription) => {
+        const loadingKey = `${record.consumerId}-${record.productId}`;
+        const isApproving = actionLoading === `${loadingKey}-approve`;
+        const isDeleting = actionLoading === `${loadingKey}-delete`;
+        
+        if (record.status === 'PENDING') {
+          return (
+            <Button
+              type="primary"
+              size="small"
+              loading={isApproving}
+              onClick={() => handleApproveSubscription(record)}
+            >
+              审批通过
+            </Button>
+          );
+        } else if (record.status === 'APPROVED') {
+          return (
+            <Popconfirm
+              title="确定要删除这个订阅吗？"
+              description="删除后将无法恢复"
+              onConfirm={() => handleDeleteSubscription(record)}
+              okText="确定"
+              cancelText="取消"
+            >
+              <Button
+                type="default"
+                size="small"
+                danger
+                loading={isDeleting}
+              >
+                删除订阅
+              </Button>
+            </Popconfirm>
+          );
+        }
+        return null;
+      }
+    }
+  ];
+
+  const pendingCount = subscriptions.filter(s => s.status === 'PENDING').length;
+  const approvedCount = subscriptions.filter(s => s.status === 'APPROVED').length;
+
+  return (
+    <Modal
+      title={
+        <div>
+          <div className="text-lg font-semibold">订阅列表 - {consumerName}</div>
+          <div className="text-sm text-gray-500 mt-1">
+            待审批: <Badge count={pendingCount} style={{ backgroundColor: '#faad14' }} /> | 
+            已通过: <Badge count={approvedCount} style={{ backgroundColor: '#52c41a' }} />
+          </div>
+        </div>
+      }
+      open={visible}
+      onCancel={onCancel}
+      footer={null}
+      width={1000}
+      destroyOnClose
+    >
+      <Table
+        columns={columns}
+        dataSource={subscriptions}
+        rowKey="subscriptionId"
+        loading={loading}
+        pagination={pagination}
+        onChange={handleTableChange}
+        locale={{
+          emptyText: '暂无订阅记录'
+        }}
+      />
+    </Modal>
+  );
+}
+
+
+

--- a/portal-web/api-portal-admin/src/lib/api.ts
+++ b/portal-web/api-portal-admin/src/lib/api.ts
@@ -115,6 +115,18 @@ export const portalApi = {
   // 审批consumer
   approveConsumer: (consumerId: string) => {
     return api.patch(`/consumers/${consumerId}/status`)
+  },
+  // 获取Consumer的订阅列表
+  getConsumerSubscriptions: (consumerId: string, params?: { page?: number; size?: number; status?: string }) => {
+    return api.get(`/consumers/${consumerId}/subscriptions`, { params })
+  },
+  // 审批订阅申请
+  approveSubscription: (consumerId: string, productId: string) => {
+    return api.patch(`/consumers/${consumerId}/subscriptions/${productId}`)
+  },
+  // 删除订阅
+  deleteSubscription: (consumerId: string, productId: string) => {
+    return api.delete(`/consumers/${consumerId}/subscriptions/${productId}`)
   }
 }
 

--- a/portal-web/api-portal-admin/src/types/api-product.ts
+++ b/portal-web/api-portal-admin/src/types/api-product.ts
@@ -34,6 +34,7 @@ export interface ApiProduct {
   status: 'PENDING' | 'READY' | 'PUBLISHED' | string;
   createAt: string;
   enableConsumerAuth?: boolean;
+  autoApprove?: boolean;
   apiConfig?: ApiProductConfig;
   mcpConfig?: ApiProductMcpConfig;
   document?: string;

--- a/portal-web/api-portal-admin/src/types/index.ts
+++ b/portal-web/api-portal-admin/src/types/index.ts
@@ -2,6 +2,7 @@
 export * from './portal'
 export * from './api-product'
 export * from './gateway'
+export * from './subscription'
 
 // 通用API响应类型
 export interface ApiResponse<T = any> {

--- a/portal-web/api-portal-admin/src/types/subscription.ts
+++ b/portal-web/api-portal-admin/src/types/subscription.ts
@@ -1,0 +1,27 @@
+export interface Subscription {
+  subscriptionId: string;
+  consumerId: string;
+  productId: string;
+  status: 'PENDING' | 'APPROVED';
+  createAt: string;
+  updatedAt: string;
+  productName: string;
+  productType: string;
+}
+
+export interface Product {
+  productId: string;
+  name: string;
+  description?: string;
+  type: string;
+}
+
+export interface SubscriptionModalProps {
+  visible: boolean;
+  consumerId: string;
+  consumerName: string;
+  onCancel: () => void;
+}
+
+
+

--- a/portal-web/api-portal-frontend/src/types/index.ts
+++ b/portal-web/api-portal-frontend/src/types/index.ts
@@ -39,6 +39,7 @@ export interface BaseProduct {
   description: string;
   status: ProductStatus;
   enableConsumerAuth: boolean | null;
+  autoApprove?: boolean;
   type: ProductType;
   document: string | null;
   icon: string | null;


### PR DESCRIPTION
feat: 为产品添加单独审批功能

- 新增产品级autoApprove字段，在创建API产品时选择是否开启，支持单独审批配置。
- 添加AdminOrDeveloperAuth注解，支持管理员或开发者权限
- 完善消费者订阅审批逻辑
- 新增订阅管理前端组件和API接口
- 更新产品表单，支持审批配置