### PR TITLE
feat(portal): 添加 ADP MCP 服务器列表结果类并更新相关配置

### DIFF
--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/dto/result/AdpMcpServerListResult.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/dto/result/AdpMcpServerListResult.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.alibaba.apiopenplatform.dto.result;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AdpMcpServerListResult {
+
+    private Integer code;
+    
+    private String message;
+    
+    private String msg;
+    
+    private AdpMcpServerListData data;
+    
+    @Data
+    public static class AdpMcpServerListData {
+        private List<AdpMCPServerResult> records;
+        private Integer total;
+        private Integer size;
+        private Integer current;
+    }
+}

--- a/portal-web/api-portal-admin/package.json
+++ b/portal-web/api-portal-admin/package.json
@@ -20,6 +20,7 @@
     "helmet": "^7.1.0",
     "js-yaml": "^4.1.0",
     "monaco-editor": "^0.52.2",
+    "postcss": "^8.5.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-markdown": "^10.1.0",
@@ -28,8 +29,7 @@
     "react-router-dom": "^6.28.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1",
-    "terser": "^5.43.1",
-    "postcss": "^8.5.6"
+    "terser": "^5.43.1"
   },
   "resolutions": {
     "@babel/runtime": "^8.0.0-alpha.17"
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@types/js-yaml": "^4.0.9",
+    "@types/node": "^24.3.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.3",
     "@vitejs/plugin-react": "^4.7.0",

--- a/portal-web/api-portal-admin/vite.config.ts
+++ b/portal-web/api-portal-admin/vite.config.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const env = loadEnv(process.env.NODE_ENV, process.cwd(), '')
+const env = loadEnv(process.env.NODE_ENV || 'development', process.cwd(), '')
 const apiPrefix = env.VITE_API_BASE_URL
 // https://vite.dev/config/
 export default defineConfig({

--- a/portal-web/api-portal-frontend/package.json
+++ b/portal-web/api-portal-frontend/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@types/node": "^24.3.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.3",
     "@vitejs/plugin-react": "^4.6.0",

--- a/portal-web/api-portal-frontend/vite.config.ts
+++ b/portal-web/api-portal-frontend/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-const env = loadEnv(process.env.NODE_ENV, process.cwd(), '')
+const env = loadEnv(process.env.NODE_ENV || 'development', process.cwd(), '')
 const apiPrefix = env.VITE_API_BASE_URL
 
 export default defineConfig({


### PR DESCRIPTION
- 新增 AdpMcpServerListResult 类用于处理 ADP MCP 服务器列表结果
- 在 API 门户管理端和前端项目中添加 @types/node 依赖
- 修改环境变量加载逻辑，确保在不同环境下正确加载配置