### PR TITLE
fix: 修复 API Products关联服务时MCP Server搜索框逻辑错误

### DIFF
--- a/portal-web/api-portal-admin/src/components/api-product/ApiProductLinkApi.tsx
+++ b/portal-web/api-portal-admin/src/components/api-product/ApiProductLinkApi.tsx
@@ -559,7 +559,7 @@ export function ApiProductLinkApi({ apiProduct, handleRefresh }: ApiProductLinkA
                 loading={apiLoading}
                 showSearch
                 filterOption={(input, option) =>
-                  (option?.children as unknown as string)?.toLowerCase().includes(input.toLowerCase())
+                  (option?.value as unknown as string)?.toLowerCase().includes(input.toLowerCase())
                 }
                 optionLabelProp="label"
               >


### PR DESCRIPTION
- 将搜索逻辑从 option.children 改为 option.value，以确保正确匹配搜索内容


否则页面会报如下错误：
<img width="1183" height="464" alt="image" src="https://github.com/user-attachments/assets/4ef62f66-6d00-468c-8766-024c3a91b1e7" />
