### PR TITLE
fix: 修复 API Products关联服务时搜索框逻辑错误

### DIFF
--- a/portal-web/api-portal-admin/src/components/api-product/ApiProductLinkApi.tsx
+++ b/portal-web/api-portal-admin/src/components/api-product/ApiProductLinkApi.tsx
@@ -559,7 +559,7 @@ export function ApiProductLinkApi({ apiProduct, handleRefresh }: ApiProductLinkA
                 loading={apiLoading}
                 showSearch
                 filterOption={(input, option) =>
-                  (option?.children as unknown as string)?.toLowerCase().includes(input.toLowerCase())
+                  (option?.value as unknown as string)?.toLowerCase().includes(input.toLowerCase())
                 }
                 optionLabelProp="label"
               >

--- a/portal-web/api-portal-admin/src/components/api-product/ApiProductLinkApi.tsx
+++ b/portal-web/api-portal-admin/src/components/api-product/ApiProductLinkApi.tsx
@@ -465,14 +465,14 @@ export function ApiProductLinkApi({ apiProduct, handleRefresh }: ApiProductLinkA
                 loading={gatewayLoading}
                 showSearch
                 filterOption={(input, option) =>
-                  (option?.children as unknown as string)?.toLowerCase().includes(input.toLowerCase())
+                  (option?.value as unknown as string)?.toLowerCase().includes(input.toLowerCase())
                 }
                 onChange={handleGatewayChange}
                 optionLabelProp="label"
               >
                 {gateways.map(gateway => (
-                  <Select.Option 
-                    key={gateway.gatewayId} 
+                  <Select.Option
+                    key={gateway.gatewayId}
                     value={gateway.gatewayId}
                     label={gateway.gatewayName}
                   >
@@ -494,12 +494,12 @@ export function ApiProductLinkApi({ apiProduct, handleRefresh }: ApiProductLinkA
               label="Nacos实例"
               rules={[{ required: true, message: '请选择Nacos实例' }]}
             >
-              <Select 
-                placeholder="请选择Nacos实例" 
+              <Select
+                placeholder="请选择Nacos实例"
                 loading={nacosLoading}
                 showSearch
                 filterOption={(input, option) =>
-                  (option?.children as unknown as string)?.toLowerCase().includes(input.toLowerCase())
+                  (option?.value as unknown as string)?.toLowerCase().includes(input.toLowerCase())
                 }
                 onChange={handleNacosChange}
                 optionLabelProp="label"


### PR DESCRIPTION
将搜索逻辑从 option.children 改为 option.value，以确保正确匹配搜索内容

关联服务这个页面的搜索框都有这个问题，会报如下错误：

<img width="1291" height="429" alt="image" src="https://github.com/user-attachments/assets/f8d6bba1-32bf-4d86-aece-23b8ae928c76" />
