### PR TITLE
fix: 新增门户Dashboard与统一兜底提示

### DIFF
--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/controller/GatewayController.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/controller/GatewayController.java
@@ -105,7 +105,8 @@ public class GatewayController {
 
     @Operation(summary = "获取仪表板URL")
     @GetMapping("/{gatewayId}/dashboard")
-    public String getDashboard(@PathVariable String gatewayId) {
-        return gatewayService.getDashboard(gatewayId);
+    public String getDashboard(@PathVariable String gatewayId,
+                               @RequestParam(required = false, defaultValue = "API") String type) {
+        return gatewayService.getDashboard(gatewayId, type);
     }
 }

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/controller/PortalController.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/controller/PortalController.java
@@ -95,4 +95,11 @@ public class PortalController {
                                                            Pageable pageable) {
         return portalService.listSubscriptions(portalId, param, pageable);
     }
+
+    @Operation(summary = "获取门户Dashboard监控面板URL")
+    @GetMapping("/{portalId}/dashboard")
+    public String getDashboard(@PathVariable String portalId,
+                               @RequestParam(required = false, defaultValue = "Portal") String type) {
+        return portalService.getDashboard(portalId);
+    }
 }

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/GatewayService.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/GatewayService.java
@@ -105,5 +105,5 @@ public interface GatewayService {
      *
      * @return 仪表板URL
      */
-    String getDashboard(String gatewayId);
+    String getDashboard(String gatewayId,String type);
 }

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/PortalService.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/PortalService.java
@@ -117,4 +117,12 @@ public interface PortalService {
      * @return
      */
     String getDefaultPortal();
+
+    /**
+     * 获取门户的Dashboard监控面板URL
+     *
+     * @param portalId 门户ID
+     * @return Dashboard URL
+     */
+    String getDashboard(String portalId);
 }

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/AIGatewayOperator.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/AIGatewayOperator.java
@@ -136,7 +136,7 @@ public class AIGatewayOperator extends APIGOperator {
     }
 
     @Override
-    public String getDashboard(Gateway gateway) {
+    public String getDashboard(Gateway gateway,String type) {
         SLSClient ticketClient = new SLSClient(gateway.getApigConfig(),true);
         String ticket = null;
         try {
@@ -170,8 +170,20 @@ public class AIGatewayOperator extends APIGOperator {
             throw new BusinessException(ErrorCode.INTERNAL_ERROR, "Error fetching Project,Cause:" + e.getMessage());
         }
         String region = gateway.getApigConfig().getRegion();
-        String dashboardUrl = String.format("https://sls.console.aliyun.com/lognext/project/%s/dashboard/dashboard-1756276497392-966932?slsRegion=%s&sls_ticket=%s&isShare=true&hideTopbar=true&hideSidebar=true&ignoreTabLocalStorage=true", projectName,region, ticket);
-        log.info("Dashboard URL: {}", dashboardUrl);
+        String gatewayId = gateway.getGatewayId();
+        String dashboardId = "";
+        String gatewayFilter = "";
+        if (type.equals("Portal")) {
+            dashboardId = "dashboard-1758009692051-393998";
+            gatewayFilter = "";
+        } else if (type.equals("MCP")) {
+            dashboardId = "dashboard-1757483808537-433375";
+            gatewayFilter = "filters=cluster_id%%253A%%2520" + gatewayId;
+        } else if (type.equals("API")) {
+            dashboardId = "dashboard-1756276497392-966932";
+            gatewayFilter = "filters=cluster_id%%253A%%2520" + gatewayId;;
+        } 
+        String dashboardUrl = String.format("https://sls.console.aliyun.com/lognext/project/%s/dashboard/%s?%s&slsRegion=%s&sls_ticket=%s&isShare=true&hideTopbar=true&hideSidebar=true&ignoreTabLocalStorage=true", projectName, dashboardId, gatewayFilter, region, ticket);        log.info("Dashboard URL: {}", dashboardUrl);
         return dashboardUrl;
     }
 

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/APIGOperator.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/APIGOperator.java
@@ -385,7 +385,7 @@ public class APIGOperator extends GatewayOperator<APIGClient> {
     }
 
     @Override
-    public String getDashboard(Gateway gateway) {
+    public String getDashboard(Gateway gateway,String type) {
         SLSClient ticketClient = new SLSClient(gateway.getApigConfig(),true);
         String ticket = null;
         try {
@@ -419,7 +419,16 @@ public class APIGOperator extends GatewayOperator<APIGClient> {
             throw new BusinessException(ErrorCode.INTERNAL_ERROR, "Error fetching Project,Cause:" + e.getMessage());
         }
         String region = gateway.getApigConfig().getRegion();
-        String dashboardUrl = String.format("https://sls.console.aliyun.com/lognext/project/%s/dashboard/dashboard-1756276497392-966932?slsRegion=%s&sls_ticket=%s&isShare=true&hideTopbar=true&hideSidebar=true&ignoreTabLocalStorage=true", projectName,region, ticket);
+        String gatewayId = gateway.getGatewayId();
+        String dashboardId = "";
+        if (type.equals("Portal")) {
+            dashboardId = "dashboard-1758009692051-393998";
+        } else if (type.equals("MCP")) {
+            dashboardId = "dashboard-1757483808537-433375";
+        } else if (type.equals("API")) {
+            dashboardId = "dashboard-1756276497392-966932";
+        }
+        String dashboardUrl = String.format("https://sls.console.aliyun.com/lognext/project/%s/dashboard/%s?filters=cluster_id%%253A%%2520%s&slsRegion=%s&sls_ticket=%s&isShare=true&hideTopbar=true&hideSidebar=true&ignoreTabLocalStorage=true", projectName, dashboardId, gatewayId, region, ticket);        log.info("Dashboard URL: {}", dashboardUrl);
         return dashboardUrl;
     }
 

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/AdpAIGatewayOperator.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/AdpAIGatewayOperator.java
@@ -332,7 +332,7 @@ public class AdpAIGatewayOperator extends GatewayOperator {
     }
 
     @Override
-    public String getDashboard(Gateway gateway) {
+    public String getDashboard(Gateway gateway,String type) {
         return null;
     }
 

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/GatewayOperator.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/GatewayOperator.java
@@ -71,7 +71,7 @@ public abstract class GatewayOperator<T> {
      * @param gateway 网关实体
      * @return 仪表盘访问链接
      */
-    abstract public String getDashboard(Gateway gateway);
+    abstract public String getDashboard(Gateway gateway,String type);
 
     @SuppressWarnings("unchecked")
     protected T getClient(Gateway gateway) {

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/HigressOperator.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/HigressOperator.java
@@ -231,8 +231,8 @@ public class HigressOperator extends GatewayOperator<HigressClient> {
         return GatewayType.HIGRESS;
     }
 
-    @Override
-    public String getDashboard(Gateway gateway) {
+        @Override
+        public String getDashboard(Gateway gateway,String type) {
         throw new UnsupportedOperationException("Higress gateway does not support getting dashboard");
     }
 

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/impl/GatewayServiceImpl.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/impl/GatewayServiceImpl.java
@@ -240,8 +240,8 @@ public class GatewayServiceImpl implements GatewayService, ApplicationContextAwa
     }
 
     @Override
-    public String getDashboard(String gatewayId) {
+    public String getDashboard(String gatewayId,String type) {
         Gateway gateway = findGateway(gatewayId);
-        return getOperator(gateway).getDashboard(gateway);
+        return getOperator(gateway).getDashboard(gateway,type); //type: Portal,MCP,API
     }
 }

--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/impl/ProductServiceImpl.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/impl/ProductServiceImpl.java
@@ -387,8 +387,16 @@ public class ProductServiceImpl implements ProductService {
         if (productRef.getGatewayId() == null) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST, "该产品尚未关联网关服务");
         }
-
+        // 基于产品类型选择Dashboard类型
+        Product product = findProduct(productId);
+        String dashboardType;
+        if (product.getType() == ProductType.MCP_SERVER) {
+            dashboardType = "MCP";
+        } else {
+            // REST_API、HTTP_API 统一走 API 面板
+            dashboardType = "API";
+        }
         // 通过网关服务获取Dashboard URL
-        return gatewayService.getDashboard(productRef.getGatewayId());
+        return gatewayService.getDashboard(productRef.getGatewayId(), dashboardType);
     }
 }

--- a/portal-web/api-portal-admin/src/components/portal/PortalDashboard.tsx
+++ b/portal-web/api-portal-admin/src/components/portal/PortalDashboard.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react'
+import { Card, Spin, Button, Space } from 'antd'
+import { ReloadOutlined, DashboardOutlined } from '@ant-design/icons'
+import { portalApi } from '@/lib/api'
+import type { Portal } from '@/types'
+
+interface PortalDashboardProps {
+  portal: Portal
+}
+
+export const PortalDashboard: React.FC<PortalDashboardProps> = ({ portal }) => {
+  const [dashboardUrl, setDashboardUrl] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [fallback, setFallback] = useState(false)
+
+  const fetchDashboardUrl = async () => {
+    if (!portal.portalId) return
+    setLoading(true)
+    setError('')
+    try {
+      const res = await portalApi.getPortalDashboard(portal.portalId, 'Portal')
+      if (!res?.data) {
+        setFallback(true)
+      } else {
+        setDashboardUrl(res.data)
+      }
+    } catch (e: any) {
+      setError(e?.response?.data?.message || '获取监控面板失败')
+      setFallback(true)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchDashboardUrl()
+  }, [portal.portalId])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Spin size="large" />
+      </div>
+    )
+  }
+
+  if (fallback || !dashboardUrl || error) {
+    return (
+      <div className="p-6">
+        <div className="w-full h-[600px] flex items-center justify-center text-gray-500">
+          Dashboard 发布中，敬请期待
+        </div>
+        <div className="mt-4 text-right">
+          <Button onClick={fetchDashboardUrl} loading={loading}>刷新</Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold flex items-center gap-2">
+            <DashboardOutlined className="text-blue-500" />
+            Dashboard 监控面板
+          </h2>
+          <p className="text-gray-500 mt-2">实时监控 {portal.name} 的访问与性能</p>
+        </div>
+        <Space>
+          <Button icon={<ReloadOutlined />} onClick={fetchDashboardUrl} loading={loading}>刷新</Button>
+        </Space>
+      </div>
+
+      <Card title="监控面板" className="w-full">
+        <div className="w-full h-[600px] border rounded-lg overflow-hidden">
+          <iframe
+            src={dashboardUrl}
+            title={`${portal.name} Dashboard`}
+            className="w-full h-full border-0"
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+            onError={() => setFallback(true)}
+          />
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+

--- a/portal-web/api-portal-admin/src/lib/api.ts
+++ b/portal-web/api-portal-admin/src/lib/api.ts
@@ -57,6 +57,10 @@ export const portalApi = {
   getPortals: (params?: { page?: number; size?: number }) => {
     return api.get(`/portals`, { params })
   },
+  // 获取Portal Dashboard URL
+  getPortalDashboard: (portalId: string, type: string = 'Portal') => {
+    return api.get(`/portals/${portalId}/dashboard`, { params: { type } })
+  },
   deletePortal: (portalId: string) => {
     return api.delete(`/portals/${portalId}`)
   },

--- a/portal-web/api-portal-admin/src/pages/PortalDetail.tsx
+++ b/portal-web/api-portal-admin/src/pages/PortalDetail.tsx
@@ -8,13 +8,15 @@ import {
   GlobalOutlined,
   FileTextOutlined,
   TeamOutlined,
-  SettingOutlined
+  SettingOutlined,
+  DashboardOutlined
 } from '@ant-design/icons'
 import { PortalOverview } from '@/components/portal/PortalOverview'
 import { PortalPublishedApis } from '@/components/portal/PortalPublishedApis'
 import { PortalDevelopers } from '@/components/portal/PortalDevelopers'
 import { PortalConsumers } from '@/components/portal/PortalConsumers'
 import { PortalSettings } from '@/components/portal/PortalSettings'
+import { PortalDashboard } from '@/components/portal/PortalDashboard'
 import { portalApi } from '@/lib/api'
 import { Portal } from '@/types'
 
@@ -47,6 +49,12 @@ const menuItems = [
   //   icon: UserOutlined,
   //   description: "消费者管理"
   // },
+  {
+    key: "dashboard",
+    label: "Dashboard",
+    icon: DashboardOutlined,
+    description: "监控面板"
+  },
   {
     key: "settings",
     label: "Settings",
@@ -115,6 +123,8 @@ export default function PortalDetail() {
         return <PortalPublishedApis portal={portal} />
       case "developers":
         return <PortalDevelopers portal={portal} />
+      case "dashboard":
+        return <PortalDashboard portal={portal} />
       case "consumers":
         return <PortalConsumers portal={portal} />
       case "settings":


### PR DESCRIPTION
- 后端：新增 Portal getDashboard 接口；Product 按类型(API/MCP)选择仪表盘；Gateway 支持 type 参数
- 前端：admin 门户详情新增 Dashboard 页签；新增 portalApi.getPortalDashboard
- 前后端统一：获取失败/空URL/iframe错误时显示“Dashboard 发布中，敬请期待”