### PR TITLE
:bug: fix: fixed an issue where the Mcp path obtained when adding the Higress Mcp Server to Himarket was incorrect.

### DIFF
--- a/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/HigressOperator.java
+++ b/portal-server/src/main/java/com/alibaba/apiopenplatform/service/gateway/HigressOperator.java
@@ -160,7 +160,7 @@ public class HigressOperator extends GatewayOperator<HigressClient> {
         boolean isDirect = "direct_route".equalsIgnoreCase(higressMCPConfig.getType());
         DirectRouteConfig directRouteConfig = higressMCPConfig.getDirectRouteConfig();
         String transportType = isDirect ? directRouteConfig.getTransportType() : null;
-        String path = isDirect ? directRouteConfig.getPath() : "/mcp-servers/" + higressMCPConfig.getName();
+        String path = "/mcp-servers/" + higressMCPConfig.getName();
 
         c.setPath(path);
         List<String> domains = higressMCPConfig.getDomains();


### PR DESCRIPTION
## Description   

- 修复内容: 按照higress的命名规范 直接使用 /mcp-servers/[McpName]   
- 修改文件:  HigressOperator.java   

## Related Issues

Fix  #107   

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] Code is self-reviewed