### PR TITLE
docs: update README and README_zh deploy path

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Use the `deploy.sh` script to deploy Himarket, Higress, and Nacos with data init
 ```bash
 # Clone repository
 git clone https://github.com/higress-group/himarket.git
-cd himarket/deploy/docker
+cd himarket/deploy/docker/scripts
 
 # Deploy full stack and initialize
 ./deploy.sh install
@@ -143,7 +143,7 @@ cd himarket/deploy/docker
 # Service URLs
 # Admin portal: http://localhost:5174
 # Developer portal: http://localhost:5173
-# Backend API: http://localhost:8080
+# Backend API: http://localhost:8081
 ```
 
 > For detailed Docker deployment instructions, please refer to [Docker Deployment Guide](./deploy/docker/Docker部署脚本说明.md)
@@ -160,7 +160,7 @@ Use the `deploy.sh` script to deploy Himarket to Kubernetes cluster.
 ```bash
 # Clone repository
 git clone https://github.com/higress-group/himarket.git
-cd himarket/deploy/helm
+cd himarket/deploy/helm/scripts
 
 # Deploy full stack and initialize
 ./deploy.sh install

--- a/README_zh.md
+++ b/README_zh.md
@@ -129,7 +129,7 @@ npm run dev
 ```bash
 # 克隆项目
 git clone https://github.com/higress-group/himarket.git
-cd himarket/deploy/docker
+cd himarket/deploy/docker/scripts
 
 # 部署全栈服务并初始化
 ./deploy.sh install
@@ -143,7 +143,7 @@ cd himarket/deploy/docker
 # 服务地址
 # 管理后台地址：http://localhost:5174
 # 开发者门户地址：http://localhost:5173
-# 后端 API 地址：http://localhost:8080
+# 后端 API 地址：http://localhost:8081
 ```
 
 > 详细的 Docker 部署说明请参考 [Docker 部署文档](./deploy/docker/Docker部署脚本说明.md)
@@ -160,7 +160,7 @@ cd himarket/deploy/docker
 ```bash
 # 克隆项目
 git clone https://github.com/higress-group/himarket.git
-cd himarket/deploy/helm
+cd himarket/deploy/helm/scripts
 
 # 部署全栈服务并初始化
 ./deploy.sh install


### PR DESCRIPTION
## Description

This PR fixes the path to the one-click deployment script and the port number of the HiMarket server in the README.md and README_zh.md documents.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] Documentation updated (if applicable)


