### PR TITLE
feat(auth): implement subscription-based credential retrieval for products

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/service/ConsumerService.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/ConsumerService.java
@@ -172,4 +172,15 @@ public interface ConsumerService {
      * @return ConsumerResult
      */
     ConsumerResult getPrimaryConsumer();
+
+    /**
+     * Get credential context for a specific product subscription.
+     * This method retrieves the subscription-specific credentials needed
+     * to access a product (e.g., MCP server on ADP AI Gateway).
+     *
+     * @param consumerId the consumer ID
+     * @param productId the product ID
+     * @return credential context with headers and query params, or empty context if not found
+     */
+    CredentialContext getCredentialForProduct(String consumerId, String productId);
 }


### PR DESCRIPTION
## 📝 Description

- 为 `ConsumerService` 添加 `getCredentialForProduct` 方法，支持获取特定产品订阅的凭证
- 在 `ChatService` 中优化 MCP 配置构建逻辑，优先使用产品特定的订阅凭证
- 当产品没有特定订阅凭证时，自动回退到默认凭证

## ✅ Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## 🧪 Testing

- [x] Unit tests pass locally
- [x] Manual testing completed
- 测试有订阅凭证的产品能够获取到正确的 API Key
- 测试无订阅凭证时能够正确回退到默认凭证

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend, `npm run lint:fix` for frontend)
- [x] Code is self-reviewed
- [x] No breaking changes
- [x] All CI checks pass