### PR TITLE
fix: strip UTF-8 BOM from SKILL.md before parsing YAML front matter

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/core/skill/SkillZipParser.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/core/skill/SkillZipParser.java
@@ -179,6 +179,9 @@ public final class SkillZipParser {
     }
 
     private static Skill parseSkillMarkdown(String markdownContent, String namespaceId) {
+        if (markdownContent.startsWith("\uFEFF")) {
+            markdownContent = markdownContent.substring(1);
+        }
         Matcher matcher = YAML_FRONT_MATTER.matcher(markdownContent);
         if (!matcher.matches()) {
             throw new BusinessException(


### PR DESCRIPTION
## 📝 Description

- Windows 用户创建的 SKILL.md 文件可能包含 UTF-8 BOM（`EF BB BF`），导致上传 skill ZIP 包时 YAML front matter 正则匹配失败，报错"SKILL.md 必须包含 YAML front matter (---)"
- 在 `SkillZipParser.parseSkillMarkdown` 方法中正则匹配前先 strip BOM 字符（`\uFEFF`），使解析器兼容带 BOM 的文件

## ✅ Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## 🧪 Testing

- [x] Manual testing completed
- 使用带 UTF-8 BOM 的 SKILL.md 文件打包上传，验证可正常解析

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend)
- [x] Code is self-reviewed
- [x] No breaking changes
- [x] All CI checks pass