### PR TITLE
fix: improve MCP tool parameter handling and upgrade agentscope

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/manager/ChatBotManager.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/manager/ChatBotManager.java
@@ -294,8 +294,12 @@ public class ChatBotManager {
      */
     private void registerTool(Toolkit toolkit, McpClientWrapper client, McpSchema.Tool tool) {
         try {
+            java.util.Set<String> required =
+                    tool.inputSchema() != null && tool.inputSchema().required() != null
+                            ? new java.util.HashSet<>(tool.inputSchema().required())
+                            : java.util.Collections.emptySet();
             Map<String, Object> parameters =
-                    McpTool.convertMcpSchemaToParameters(tool.inputSchema());
+                    McpTool.convertMcpSchemaToParameters(tool.inputSchema(), required);
             McpTool mcpTool =
                     new McpTool(
                             tool.name(),

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/service/dashscope/DashScopeImageChatModel.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/service/dashscope/DashScopeImageChatModel.java
@@ -206,7 +206,7 @@ public class DashScopeImageChatModel extends ChatModelBase {
     public static class DashScopeImageHttpClient extends DashScopeHttpClient {
 
         public DashScopeImageHttpClient(HttpTransport transport, String apiKey, String baseUrl) {
-            super(transport, apiKey, baseUrl);
+            super(transport, apiKey, baseUrl, null, null);
         }
 
         /**

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <caffeine.version>3.2.3</caffeine.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <agentscope.version>1.0.6</agentscope.version>
+        <agentscope.version>1.0.10</agentscope.version>
         <jackson-databind.version>2.17.2</jackson-databind.version>
         <openai.java.version>4.6.1</openai.java.version>
         <dashscope.java.version>2.22.4</dashscope.java.version>


### PR DESCRIPTION
## 📝 Description

- 修复 MCP 工具 schema 转换时的 required 参数处理，确保工具调用参数正确传递
- 修复 DashScope 图像模型客户端构造函数调用，添加缺失的参数以兼容新版本 API
- 升级 agentscope 版本从 1.0.6 到 1.0.10，修复兼容性问题

## 🔗 Related Issues

Fix #154

## ✅ Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## 🧪 Testing

- [x] Code compiles successfully
- [x] Changes are backwards compatible

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend, `npm run lint:fix` for frontend)
- [x] Code is self-reviewed
- [x] No breaking changes