### PR TITLE
fix: web search remains enabled after being disabled

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/manager/ChatBotManager.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/manager/ChatBotManager.java
@@ -502,6 +502,20 @@ public class ChatBotManager {
 
         sb.append("|");
 
+        // Body Params (sorted)
+        if (request.getBodyParams() != null && !request.getBodyParams().isEmpty()) {
+            sb.append("body:{");
+            request.getBodyParams().entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(
+                            entry ->
+                                    sb.append(entry.getKey())
+                                            .append("=")
+                                            .append(entry.getValue())
+                                            .append(","));
+            sb.append("}|");
+        }
+
         // MCP Tool URLs (sorted)
         sb.append("mcp:");
         if (CollUtil.isNotEmpty(request.getMcpConfigs())) {


### PR DESCRIPTION
fix: resolve issue where network search persists after disabling network switch in HiChat

Description
Problem: Identified a bug in the HiMarket HiChat page where the application could still perform network searches even after the user explicitly disabled the "Network" switch.
Solution: Modified the chat request caching strategy. This fix addresses the issue where the gateway continued to execute network searches despite the user disabling the network option.
Impact: Ensures the network switch state is strictly respected in HiChat, preventing unintended background data usage and aligning the search logic with user preferences.

中文描述
问题: 修复了 HiMarket 中 HiChat 页面联网搜索逻辑漏洞，首轮对话开启联网搜索，如果接下来用户关闭联网搜索开关后，仍然会进行联网搜索。
解决方案: 问题原因是代码逻辑中对enableWebSearch参数进行了缓存，因此新一轮对话中即使这个值发生了改变，也还是取了初始设置的值。因此需要修改 Chat 请求缓存策略，修复用户在取消联网后，网关仍然可以进行联网搜索的问题。

Type of Change
Bug fix (non-breaking change which fixes an issue)

Testing
Steps to reproduce and verify the fix:
Open the HiMarket application and navigate to the HiChat page.
Verify: Ensure the "Network" switch is initially ON and send a request to confirm network search is functioning.
Action: Toggle the "Network" switch to OFF.
Verify: Attempt to send a new request.
Result: Confirm that no network search is performed (the request should rely on local context or be blocked, with no external search traffic observed).

中文测试步骤
打开 HiMarket 应用并进入 HiChat 页面。
验证: 确保“联网”开关初始为开启状态，发送请求确认联网功能正常。
操作: 将“联网”开关切换至关闭状态。
验证: 尝试重新发送请求。
结果: 确认无联网搜索行为。