### PR TITLE
fix(chat): 修复简单问答不返回 ASSISTANT 事件导致页面卡住的问题

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/ChatFormatter.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/ChatFormatter.java
@@ -47,6 +47,9 @@ import reactor.core.publisher.Flux;
 @Slf4j
 public class ChatFormatter {
 
+    /** Tracks whether any text content has been streamed (via isLast=false REASONING events) */
+    private boolean hasStreamedText = false;
+
     public Flux<ChatEvent> format(Event event, ChatContext chatContext) {
         try {
             Msg msg = event.getMessage();
@@ -105,12 +108,22 @@ public class ChatFormatter {
         if (StrUtil.isNotBlank(textContent)) {
             if (isLast) {
                 getUsage(msg, chatContext);
-                // Skip final complete text to avoid duplication
-                log.debug(
-                        "Skipping final complete text (isLast=true, length={})",
-                        textContent.length());
+                if (hasStreamedText) {
+                    // Streaming chunks were already sent, skip to avoid duplication
+                    log.debug(
+                            "Skipping final complete text (already streamed, length={})",
+                            textContent.length());
+                } else {
+                    // No streaming chunks were sent (e.g., simple/short answers),
+                    // emit the final text so the frontend receives content
+                    log.debug(
+                            "Emitting final text as no streaming chunks were sent (length={})",
+                            textContent.length());
+                    chunks.add(ChatEvent.text(chatId, textContent));
+                }
             } else {
                 // Send incremental chunks for streaming
+                hasStreamedText = true;
                 chunks.add(ChatEvent.text(chatId, textContent));
             }
         }


### PR DESCRIPTION
## 📝 Description

修复体验中心简单问答时页面一直卡在加载状态（三个蓝色圆点）的问题。

**根因分析：**

`ChatFormatter.handleReasoning()` 在 `isLast=true` 时无条件跳过文本内容（原设计是为了避免与流式 chunk 重复）。但对于简单/短回答，模型只产生一个 `REASONING(isLast=true)` 事件，没有 `isLast=false` 的流式中间 chunk，导致没有任何 `ASSISTANT` 事件被发送到前端。

- 简单问答事件流：`START` → *(无 ASSISTANT)* → `DONE` — 页面卡住
- 复杂问答事件流：`START` → `ASSISTANT`(多个 chunk) → `DONE` — 正常显示

**修复方案：**

在 `ChatFormatter` 中增加 `hasStreamedText` 标志，跟踪是否已经通过流式 chunk 发送过文本：
- `isLast=false` 发送文本时标记 `hasStreamedText = true`
- `isLast=true` 时：已有流式内容则跳过（避免重复）；无流式内容则发送（确保前端收到回答）

## 🔗 Related Issues

Fix higress-group/himarket#129

## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] Manual testing completed
- [x] All tests pass locally

已本地测试验证：简单问答（如"你好"）现在能正常返回 ASSISTANT 事件并在页面上显示回答内容。

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend, `npm run lint:fix` for frontend)
- [x] Code is self-reviewed
- [x] Comments added for complex code
- [x] No breaking changes (or migration guide provided)

🤖 Generated with [Qoder][https://qoder.com]