### PR TITLE
fix: update Nacos SQL schema and Skill service compatibility

### DIFF
--- a/deploy/helm/nacos/sql/mysql-schema.sql
+++ b/deploy/helm/nacos/sql/mysql-schema.sql
@@ -17,7 +17,7 @@
 /******************************************/
 /*   表名称 = config_info                  */
 /******************************************/
-CREATE TABLE IF NOT EXISTS `config_info` (
+CREATE TABLE `config_info` (
                                `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
                                `data_id` varchar(255) NOT NULL COMMENT 'data_id',
                                `group_id` varchar(128) DEFAULT NULL COMMENT 'group_id',
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS `config_info` (
 /******************************************/
 /*   表名称 = config_info  since 2.5.0                */
 /******************************************/
-CREATE TABLE IF NOT EXISTS `config_info_gray` (
+CREATE TABLE `config_info_gray` (
                                     `id` bigint unsigned NOT NULL AUTO_INCREMENT COMMENT 'id',
                                     `data_id` varchar(255) NOT NULL COMMENT 'data_id',
                                     `group_id` varchar(128) NOT NULL COMMENT 'group_id',
@@ -66,7 +66,7 @@ CREATE TABLE IF NOT EXISTS `config_info_gray` (
 /******************************************/
 /*   表名称 = config_tags_relation         */
 /******************************************/
-CREATE TABLE IF NOT EXISTS `config_tags_relation` (
+CREATE TABLE `config_tags_relation` (
                                         `id` bigint(20) NOT NULL COMMENT 'id',
                                         `tag_name` varchar(128) NOT NULL COMMENT 'tag_name',
                                         `tag_type` varchar(64) DEFAULT NULL COMMENT 'tag_type',
@@ -82,7 +82,7 @@ CREATE TABLE IF NOT EXISTS `config_tags_relation` (
 /******************************************/
 /*   表名称 = group_capacity               */
 /******************************************/
-CREATE TABLE IF NOT EXISTS `group_capacity` (
+CREATE TABLE `group_capacity` (
                                   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
                                   `group_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'Group ID，空字符表示整个集群',
                                   `quota` int(10) unsigned NOT NULL DEFAULT '0' COMMENT '配额，0表示使用默认值',
@@ -100,7 +100,7 @@ CREATE TABLE IF NOT EXISTS `group_capacity` (
 /******************************************/
 /*   表名称 = his_config_info              */
 /******************************************/
-CREATE TABLE IF NOT EXISTS `his_config_info` (
+CREATE TABLE `his_config_info` (
                                    `id` bigint(20) unsigned NOT NULL COMMENT 'id',
                                    `nid` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'nid, 自增标识',
                                    `data_id` varchar(255) NOT NULL COMMENT 'data_id',
@@ -128,7 +128,7 @@ CREATE TABLE IF NOT EXISTS `his_config_info` (
 /******************************************/
 /*   表名称 = tenant_capacity              */
 /******************************************/
-CREATE TABLE IF NOT EXISTS `tenant_capacity` (
+CREATE TABLE `tenant_capacity` (
                                    `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
                                    `tenant_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'Tenant ID',
                                    `quota` int(10) unsigned NOT NULL DEFAULT '0' COMMENT '配额，0表示使用默认值',
@@ -144,7 +144,7 @@ CREATE TABLE IF NOT EXISTS `tenant_capacity` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='租户容量信息表';
 
 
-CREATE TABLE IF NOT EXISTS `tenant_info` (
+CREATE TABLE `tenant_info` (
                                `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
                                `kp` varchar(128) NOT NULL COMMENT 'kp',
                                `tenant_id` varchar(128) default '' COMMENT 'tenant_id',
@@ -158,19 +158,19 @@ CREATE TABLE IF NOT EXISTS `tenant_info` (
                                KEY `idx_tenant_id` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='tenant_info';
 
-CREATE TABLE IF NOT EXISTS `users` (
+CREATE TABLE `users` (
                          `username` varchar(50) NOT NULL PRIMARY KEY COMMENT 'username',
                          `password` varchar(500) NOT NULL COMMENT 'password',
                          `enabled` boolean NOT NULL COMMENT 'enabled'
 );
 
-CREATE TABLE IF NOT EXISTS `roles` (
+CREATE TABLE `roles` (
                          `username` varchar(50) NOT NULL COMMENT 'username',
                          `role` varchar(50) NOT NULL COMMENT 'role',
                          UNIQUE INDEX `idx_user_role` (`username` ASC, `role` ASC) USING BTREE
 );
 
-CREATE TABLE IF NOT EXISTS `permissions` (
+CREATE TABLE `permissions` (
                                `role` varchar(50) NOT NULL COMMENT 'role',
                                `resource` varchar(128) NOT NULL COMMENT 'resource',
                                `action` varchar(8) NOT NULL COMMENT 'action',
@@ -181,7 +181,7 @@ CREATE TABLE IF NOT EXISTS `permissions` (
 /******************************************/
 /*   表名称 = pipeline_execution           */
 /******************************************/
-CREATE TABLE IF NOT EXISTS `pipeline_execution` (
+CREATE TABLE `pipeline_execution` (
     `execution_id`  varchar(64)  NOT NULL COMMENT '执行ID',
     `resource_type` varchar(32)  NOT NULL COMMENT '资源类型',
     `resource_name` varchar(256) NOT NULL COMMENT '资源名称',
@@ -197,7 +197,7 @@ CREATE TABLE IF NOT EXISTS `pipeline_execution` (
 /******************************************/
 /*   表名称 = ai_resource                 */
 /******************************************/
-CREATE TABLE IF NOT EXISTS `ai_resource` (
+CREATE TABLE `ai_resource` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
     `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
     `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
@@ -208,13 +208,14 @@ CREATE TABLE IF NOT EXISTS `ai_resource` (
     `namespace_id` varchar(128) NOT NULL DEFAULT '' COMMENT '命名空间ID',
     `biz_tags` varchar(1024) DEFAULT NULL COMMENT '业务标签',
     `ext` longtext DEFAULT NULL COMMENT '扩展信息(JSON)',
+    `c_from` varchar(256) NOT NULL DEFAULT 'local' COMMENT '来源标识(导入/同步来源)',
     `version_info` longtext DEFAULT NULL COMMENT '版本信息(JSON)',
     `meta_version` bigint(20) NOT NULL DEFAULT 1 COMMENT '元数据版本(乐观锁)',
     `scope` varchar(16) NOT NULL DEFAULT 'PRIVATE' COMMENT '可见性: PUBLIC/PRIVATE',
     `owner` varchar(128) NOT NULL DEFAULT '' COMMENT '创建者用户名',
     `download_count` bigint(20) NOT NULL DEFAULT 0 COMMENT '下载次数',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`,`name`,`type`),
+    UNIQUE KEY `uk_ai_resource_ns_name_type` (`namespace_id`,`name`,`type`,`c_from`),
     KEY `idx_ai_resource_name` (`name`),
     KEY `idx_ai_resource_type` (`type`),
     KEY `idx_ai_resource_gmt_modified` (`gmt_modified`)
@@ -223,7 +224,7 @@ CREATE TABLE IF NOT EXISTS `ai_resource` (
 /******************************************/
 /*   表名称 = ai_resource_version         */
 /******************************************/
-CREATE TABLE IF NOT EXISTS `ai_resource_version` (
+CREATE TABLE `ai_resource_version` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
     `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
     `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
@@ -243,4 +244,3 @@ CREATE TABLE IF NOT EXISTS `ai_resource_version` (
     KEY `idx_ai_resource_ver_status` (`status`),
     KEY `idx_ai_resource_ver_gmt_modified` (`gmt_modified`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源版本表';
-

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
@@ -150,7 +150,7 @@ public class SkillServiceImpl implements SkillService {
             Skill skill = fetchSkill(ref, version);
             return FileTreeBuilder.build(skill);
         } catch (Exception e) {
-            log.warn("Failed to fetch file tree for Skill {}", ref.getSkillName());
+            log.warn("Failed to fetch file tree for Skill {}", ref.getSkillName(), e);
             return Collections.emptyList();
         }
     }
@@ -656,7 +656,8 @@ public class SkillServiceImpl implements SkillService {
     private void syncSkillGroup(String nacosId, String namespace, List<Product> products) {
         try {
             AiMaintainerService aiService = nacosService.getAiMaintainerService(nacosId);
-            Page<SkillSummary> page = aiService.skill().listSkills(namespace, 1, Integer.MAX_VALUE);
+            Page<SkillSummary> page =
+                    aiService.skill().listSkills(namespace, null, null, 1, Integer.MAX_VALUE);
 
             if (page == null || CollUtil.isEmpty(page.getPageItems())) {
                 return;


### PR DESCRIPTION
## 📝 Description

- Remove `IF NOT EXISTS` from Nacos `CREATE TABLE` statements for cleaner schema initialization
- Add `c_from` column to `ai_resource` table for tracking import/sync source
- Update unique key on `ai_resource` to include `c_from` field, allowing same-name resources from different sources
- Update `listSkills` call in `SkillServiceImpl` to match new Nacos SDK method signature
- Improve error logging in `SkillServiceImpl` with full stack trace

## 🔗 Related Issues



## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] All tests pass locally

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend, `npm run lint:fix` for frontend)
- [x] Code is self-reviewed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

🤖 Generated with [Qoder][https://qoder.com]