### PR TITLE
feat(deploy): add Nacos sync hooks for Skills/Workers auto-import

### DIFF
--- a/deploy/docker/hooks/post_ready.d/65-sync-nacos-market.sh
+++ b/deploy/docker/hooks/post_ready.d/65-sync-nacos-market.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Nacos Skills/Workers 同步与发布钩子 (Docker 环境)
+# 由 install.sh post_ready hook 自动调用
+#
+# 功能:
+#   1. 在 HiMarket 中注册 Nacos 实例
+#   2. 从 Nacos 导入 Skills 和 Workers
+#   3. 将导入的产品发布到默认门户
+#
+# 环境变量:
+#   SKIP_NACOS_SYNC      - 设为 true 跳过执行 (默认 false)
+#   ADMIN_USERNAME       - HiMarket 管理员用户名 (默认 admin)
+#   ADMIN_PASSWORD       - HiMarket 管理员密码 (默认 admin)
+#   NACOS_ADMIN_PASSWORD - Nacos 管理员密码 (默认 nacos)
+# =============================================================================
+
+set -euo pipefail
+
+# ── 加载环境变量 ─────────────────────────────────────────────────────────────
+ENV_FILE="${HOME}/himarket-install.env"
+if [[ -f "${ENV_FILE}" ]]; then
+  set -a; . "${ENV_FILE}"; set +a
+fi
+
+# ── 跳过检查 ─────────────────────────────────────────────────────────────────
+if [[ "${SKIP_NACOS_SYNC:-false}" == "true" ]]; then
+  echo "[sync-nacos-market] SKIP_NACOS_SYNC=true，跳过 Nacos 同步"
+  exit 0
+fi
+
+# ── 凭据默认值 ───────────────────────────────────────────────────────────────
+ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
+NACOS_ADMIN_PASSWORD="${NACOS_ADMIN_PASSWORD:-nacos}"
+
+# ── 全局变量（Docker 环境使用 localhost） ────────────────────────────────────
+HIMARKET_HOST="http://localhost:5174"
+AUTH_TOKEN=""
+API_RESPONSE=""
+API_HTTP_CODE=""
+NACOS_ID=""
+PORTAL_ID=""
+
+MAX_RETRIES=3
+RETRY_DELAY=5
+
+# ── 统计 ─────────────────────────────────────────────────────────────────────
+SKILL_SUCCESS=0
+SKILL_SKIPPED=0
+WORKER_SUCCESS=0
+WORKER_SKIPPED=0
+PUBLISH_SUCCESS=0
+PUBLISH_SKIPPED=0
+PUBLISH_FAILED=0
+
+log() { echo "[sync-nacos-market $(date +'%H:%M:%S')] $*"; }
+err() { echo "[sync-nacos-market ERROR] $*" >&2; }
+
+########################################
+# 检查依赖
+########################################
+check_dependencies() {
+  for cmd in curl jq; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      err "未找到 $cmd 命令，请先安装"
+      exit 1
+    fi
+  done
+}
+
+########################################
+# HiMarket API 通用调用
+########################################
+call_himarket_api() {
+  local api_name="$1"
+  local method="$2"
+  local path="$3"
+  local body="${4:-}"
+  local max_attempts="${5:-$MAX_RETRIES}"
+  local max_time="${6:-30}"
+
+  local url="${HIMARKET_HOST}${path}"
+  local attempt=1
+
+  while (( attempt <= max_attempts )); do
+    if (( max_attempts > 1 )); then
+      log "调用 [${api_name}]: ${method} ${url} (第 ${attempt}/${max_attempts} 次)"
+    else
+      log "调用 [${api_name}]: ${method} ${url}"
+    fi
+
+    local curl_args=(-sS -w "\nHTTP_CODE:%{http_code}" -X "${method}" "${url}"
+      -H "Content-Type: application/json"
+      -H "Accept: application/json, text/plain, */*"
+      --connect-timeout 10 --max-time "${max_time}")
+
+    if [[ -n "${AUTH_TOKEN}" ]]; then
+      curl_args+=(-H "Authorization: Bearer ${AUTH_TOKEN}")
+    fi
+
+    if [[ -n "${body}" ]]; then
+      curl_args+=(--data "${body}")
+    fi
+
+    local result
+    result=$(curl "${curl_args[@]}" 2>&1 || echo "HTTP_CODE:000")
+
+    local http_code="" response=""
+    if [[ "$result" =~ HTTP_CODE:([0-9]{3}) ]]; then
+      http_code="${BASH_REMATCH[1]}"
+      response=$(echo "$result" | sed '/HTTP_CODE:/d')
+    else
+      http_code="000"
+      response="$result"
+    fi
+
+    API_RESPONSE="$response"
+    API_HTTP_CODE="$http_code"
+
+    # 成功或幂等
+    if [[ "$http_code" =~ ^2[0-9]{2}$ ]] || [[ "$http_code" == "409" ]]; then
+      return 0
+    fi
+
+    # 连接失败时重试
+    if [[ "$http_code" == "000" ]] && (( attempt < max_attempts )); then
+      log "连接失败，${RETRY_DELAY}秒后重试..."
+      sleep "${RETRY_DELAY}"
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    if (( attempt >= max_attempts )); then
+      return 1
+    fi
+
+    sleep "${RETRY_DELAY}"
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+########################################
+# Step 1: 登录 HiMarket
+########################################
+login_himarket() {
+  log "登录 HiMarket Admin..."
+
+  local body
+  body=$(jq -n \
+    --arg username "${ADMIN_USERNAME}" \
+    --arg password "${ADMIN_PASSWORD}" \
+    '{username: $username, password: $password}')
+
+  local attempt=1
+  while (( attempt <= MAX_RETRIES )); do
+    if call_himarket_api "管理员登录" "POST" "/api/v1/admins/login" "$body" 1; then
+      AUTH_TOKEN=$(echo "$API_RESPONSE" | jq -r '.data.access_token // empty' 2>/dev/null || echo "")
+      if [[ -z "${AUTH_TOKEN}" ]]; then
+        AUTH_TOKEN=$(echo "$API_RESPONSE" | jq -r '.data.token // .data.accessToken // empty' 2>/dev/null || echo "")
+      fi
+
+      if [[ -n "${AUTH_TOKEN}" ]]; then
+        log "HiMarket 登录成功"
+        return 0
+      fi
+    fi
+
+    if (( attempt < MAX_RETRIES )); then
+      log "登录失败，${RETRY_DELAY}秒后重试..."
+      sleep "${RETRY_DELAY}"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  err "HiMarket 登录失败"
+  return 1
+}
+
+########################################
+# Step 2: 注册 Nacos 实例（幂等）
+########################################
+register_nacos_instance() {
+  log "注册 Nacos 实例..."
+
+  local nacos_server_url="http://nacos:8848"
+
+  local body
+  body=$(jq -n \
+    --arg nacosName "default-nacos" \
+    --arg serverUrl "${nacos_server_url}" \
+    --arg username "nacos" \
+    --arg password "${NACOS_ADMIN_PASSWORD}" \
+    --arg description "Built-in Nacos instance" \
+    '{
+      nacosName: $nacosName,
+      serverUrl: $serverUrl,
+      username: $username,
+      password: $password,
+      description: $description
+    }')
+
+  call_himarket_api "创建Nacos实例" "POST" "/api/v1/nacos" "$body" 1 >/dev/null 2>&1 || true
+
+  # 查询获取 nacosId
+  local attempt=1
+  while (( attempt <= 3 )); do
+    call_himarket_api "查询Nacos实例" "GET" "/api/v1/nacos" "" 1 >/dev/null 2>&1 || true
+    NACOS_ID=$(echo "$API_RESPONSE" | jq -r '.data.content[0].nacosId // empty' 2>/dev/null || echo "")
+
+    if [[ -n "$NACOS_ID" ]]; then
+      log "Nacos 实例 ID: ${NACOS_ID}"
+      return 0
+    fi
+    sleep 3
+    attempt=$((attempt + 1))
+  done
+
+  err "无法获取 Nacos 实例 ID"
+  return 1
+}
+
+########################################
+# Step 3: 导入 Skills
+########################################
+import_skills() {
+  log "从 Nacos 导入 Skills..."
+
+  if call_himarket_api "导入Skills" "POST" "/api/v1/skills/import?nacosId=${NACOS_ID}&namespace=public" "" 1 120; then
+    SKILL_SUCCESS=$(echo "$API_RESPONSE" | jq -r '.data.successCount // 0' 2>/dev/null || echo "0")
+    SKILL_SKIPPED=$(echo "$API_RESPONSE" | jq -r '.data.skippedCount // 0' 2>/dev/null || echo "0")
+    log "Skills 导入完成: ${SKILL_SUCCESS} 成功, ${SKILL_SKIPPED} 跳过"
+    return 0
+  else
+    err "Skills 导入失败 (HTTP ${API_HTTP_CODE})"
+    return 1
+  fi
+}
+
+########################################
+# Step 4: 导入 Workers
+########################################
+import_workers() {
+  log "从 Nacos 导入 Workers..."
+
+  if call_himarket_api "导入Workers" "POST" "/api/v1/workers/import?nacosId=${NACOS_ID}&namespace=public" "" 1 120; then
+    WORKER_SUCCESS=$(echo "$API_RESPONSE" | jq -r '.data.successCount // 0' 2>/dev/null || echo "0")
+    WORKER_SKIPPED=$(echo "$API_RESPONSE" | jq -r '.data.skippedCount // 0' 2>/dev/null || echo "0")
+    log "Workers 导入完成: ${WORKER_SUCCESS} 成功, ${WORKER_SKIPPED} 跳过"
+    return 0
+  else
+    err "Workers 导入失败 (HTTP ${API_HTTP_CODE})"
+    return 1
+  fi
+}
+
+########################################
+# Step 5: 获取或创建 Portal
+########################################
+get_or_create_portal() {
+  local portal_name="${1:-demo}"
+
+  local body="{\"name\":\"${portal_name}\"}"
+  call_himarket_api "创建Portal" "POST" "/api/v1/portals" "$body" 1 >/dev/null 2>&1 || true
+
+  # 查询获取 portalId
+  local attempt=1 p_id=""
+  while (( attempt <= 3 )); do
+    call_himarket_api "查询Portal" "GET" "/api/v1/portals" "" 1 >/dev/null 2>&1 || true
+    p_id=$(echo "$API_RESPONSE" | jq -r '.data.content[]? // .[]? | select(.name=="'"${portal_name}"'") | .portalId' 2>/dev/null | head -1 || echo "")
+
+    if [[ -n "$p_id" ]]; then
+      echo "$p_id"
+      return 0
+    fi
+    sleep 3
+    attempt=$((attempt + 1))
+  done
+
+  return 1
+}
+
+########################################
+# Step 6: 发布产品到门户
+########################################
+publish_products_to_portal() {
+  local portal_id="$1"
+
+  log "获取 AGENT_SKILL 和 WORKER 产品列表..."
+
+  local product_ids=()
+
+  # 获取 AGENT_SKILL 产品
+  if call_himarket_api "查询Skills产品" "GET" "/api/v1/products?type=AGENT_SKILL&size=200" "" 1; then
+    local skill_ids
+    skill_ids=$(echo "$API_RESPONSE" | jq -r '.data.content[]?.productId // empty' 2>/dev/null || echo "")
+    if [[ -n "$skill_ids" ]]; then
+      while IFS= read -r pid; do
+        [[ -n "$pid" ]] && product_ids+=("$pid")
+      done <<< "$skill_ids"
+    fi
+  fi
+
+  # 获取 WORKER 产品
+  if call_himarket_api "查询Workers产品" "GET" "/api/v1/products?type=WORKER&size=200" "" 1; then
+    local worker_ids
+    worker_ids=$(echo "$API_RESPONSE" | jq -r '.data.content[]?.productId // empty' 2>/dev/null || echo "")
+    if [[ -n "$worker_ids" ]]; then
+      while IFS= read -r pid; do
+        [[ -n "$pid" ]] && product_ids+=("$pid")
+      done <<< "$worker_ids"
+    fi
+  fi
+
+  local total=${#product_ids[@]}
+  if (( total == 0 )); then
+    log "没有需要发布的产品"
+    return 0
+  fi
+
+  log "共 ${total} 个产品待发布到门户..."
+
+  local body
+  for pid in "${product_ids[@]}"; do
+    body="{\"portalId\":\"${portal_id}\"}"
+    if call_himarket_api "发布产品" "POST" "/api/v1/products/${pid}/publications" "$body" 1; then
+      if [[ "$API_HTTP_CODE" == "409" ]]; then
+        PUBLISH_SKIPPED=$((PUBLISH_SKIPPED + 1))
+      else
+        PUBLISH_SUCCESS=$((PUBLISH_SUCCESS + 1))
+      fi
+    else
+      PUBLISH_FAILED=$((PUBLISH_FAILED + 1))
+      log "产品 ${pid} 发布失败 (HTTP ${API_HTTP_CODE})"
+    fi
+  done
+}
+
+########################################
+# main
+########################################
+main() {
+  log ""
+  log "========================================"
+  log "  Nacos Skills/Workers 同步与发布"
+  log "========================================"
+  log ""
+
+  # 0. 检查依赖
+  check_dependencies
+
+  # 1. 登录 HiMarket
+  if ! login_himarket; then
+    err "HiMarket Admin 登录失败，终止同步"
+    exit 1
+  fi
+
+  # 2. 注册 Nacos 实例
+  if ! register_nacos_instance; then
+    err "Nacos 实例注册失败，终止同步"
+    exit 1
+  fi
+
+  # 3. 导入 Skills（失败不阻断）
+  import_skills || log "Skills 导入失败，继续执行..."
+
+  # 4. 导入 Workers（失败不阻断）
+  import_workers || log "Workers 导入失败，继续执行..."
+
+  # 5. 获取或创建 Portal
+  log "获取 Portal ID..."
+  PORTAL_ID=$(get_or_create_portal "demo")
+  if [[ -z "${PORTAL_ID}" ]]; then
+    err "无法获取 Portal ID，跳过产品发布"
+  else
+    log "Portal ID: ${PORTAL_ID}"
+
+    # 6. 发布产品到门户
+    publish_products_to_portal "${PORTAL_ID}"
+  fi
+
+  # 汇总
+  log ""
+  log "========================================"
+  log "  同步完成"
+  log "  Skills 导入:  ${SKILL_SUCCESS} 成功, ${SKILL_SKIPPED} 跳过"
+  log "  Workers 导入: ${WORKER_SUCCESS} 成功, ${WORKER_SKIPPED} 跳过"
+  log "  产品发布:     ${PUBLISH_SUCCESS} 成功, ${PUBLISH_SKIPPED} 跳过, ${PUBLISH_FAILED} 失败"
+  log "========================================"
+  log ""
+}
+
+main "$@"

--- a/deploy/docker/install.sh
+++ b/deploy/docker/install.sh
@@ -386,7 +386,7 @@ load_config() {
                ADMIN_USERNAME ADMIN_PASSWORD FRONT_USERNAME FRONT_PASSWORD \
                HIMARKET_LANGUAGE \
                SKIP_HOOK_ERRORS \
-               SKIP_AI_MODEL_INIT AI_MODEL_COUNT; do
+               SKIP_AI_MODEL_INIT AI_MODEL_COUNT SKIP_NACOS_SYNC; do
         eval "local _val=\"\${${var}:-}\""
         if [[ -n "${_val}" ]]; then
             saved_vars="${saved_vars} ${var}='${_val}'"

--- a/deploy/helm/hooks/post_ready.d/65-sync-nacos-market.sh
+++ b/deploy/helm/hooks/post_ready.d/65-sync-nacos-market.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Nacos Skills/Workers 同步与发布钩子 (Helm 环境)
+# 由 install.sh post_ready hook 自动调用
+#
+# 功能:
+#   1. 在 HiMarket 中注册 Nacos 实例
+#   2. 从 Nacos 导入 Skills 和 Workers
+#   3. 将导入的产品发布到默认门户
+#
+# 环境变量:
+#   SKIP_NACOS_SYNC      - 设为 true 跳过执行 (默认 false)
+#   ADMIN_USERNAME       - HiMarket 管理员用户名 (默认 admin)
+#   ADMIN_PASSWORD       - HiMarket 管理员密码 (默认 admin)
+#   NACOS_ADMIN_PASSWORD - Nacos 管理员密码 (默认 nacos)
+#   NAMESPACE            - K8s 命名空间 (默认 himarket)
+#   HIMARKET_API_URL     - HiMarket Admin 地址 (可选，自动发现)
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELM_DIR="${SCRIPT_DIR}/../.."
+
+# ── 加载 .env（如存在）─────────────────────────────────────────────────────────
+if [[ -f "${HELM_DIR}/.env" ]]; then
+  set -a
+  . "${HELM_DIR}/.env"
+  set +a
+fi
+
+NS="${NAMESPACE:-himarket}"
+
+# ── 跳过检查 ─────────────────────────────────────────────────────────────────
+if [[ "${SKIP_NACOS_SYNC:-false}" == "true" ]]; then
+  echo "[sync-nacos-market] SKIP_NACOS_SYNC=true，跳过 Nacos 同步"
+  exit 0
+fi
+
+# ── 凭据默认值 ───────────────────────────────────────────────────────────────
+ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
+NACOS_ADMIN_PASSWORD="${NACOS_ADMIN_PASSWORD:-nacos}"
+
+# ── 全局变量 ─────────────────────────────────────────────────────────────────
+HIMARKET_HOST=""
+AUTH_TOKEN=""
+API_RESPONSE=""
+API_HTTP_CODE=""
+NACOS_ID=""
+PORTAL_ID=""
+
+MAX_RETRIES=3
+RETRY_DELAY=5
+
+# ── 统计 ─────────────────────────────────────────────────────────────────────
+SKILL_SUCCESS=0
+SKILL_SKIPPED=0
+WORKER_SUCCESS=0
+WORKER_SKIPPED=0
+PUBLISH_SUCCESS=0
+PUBLISH_SKIPPED=0
+PUBLISH_FAILED=0
+
+log() { echo "[sync-nacos-market $(date +'%H:%M:%S')] $*"; }
+err() { echo "[sync-nacos-market ERROR] $*" >&2; }
+
+########################################
+# 检查依赖
+########################################
+check_dependencies() {
+  for cmd in curl jq kubectl; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      err "未找到 $cmd 命令，请先安装"
+      exit 1
+    fi
+  done
+}
+
+########################################
+# 解析 HiMarket Admin 地址
+########################################
+resolve_himarket_url() {
+  if [[ -n "${HIMARKET_API_URL:-}" ]]; then
+    HIMARKET_HOST="${HIMARKET_API_URL}"
+    log "HiMarket Admin 地址 (环境变量): ${HIMARKET_HOST}"
+    return 0
+  fi
+
+  local himarket_ip=""
+  himarket_ip=$(kubectl get svc himarket-admin -n "${NS}" -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo "")
+  if [[ -n "${himarket_ip}" ]]; then
+    HIMARKET_HOST="http://${himarket_ip}"
+    log "HiMarket Admin 地址 (kubectl): ${HIMARKET_HOST}"
+    return 0
+  fi
+
+  HIMARKET_HOST="http://himarket-admin.${NS}.svc.cluster.local"
+  log "HiMarket Admin 地址 (ClusterIP): ${HIMARKET_HOST}"
+}
+
+########################################
+# HiMarket API 通用调用
+########################################
+call_himarket_api() {
+  local api_name="$1"
+  local method="$2"
+  local path="$3"
+  local body="${4:-}"
+  local max_attempts="${5:-$MAX_RETRIES}"
+  local max_time="${6:-30}"
+
+  local url="${HIMARKET_HOST}${path}"
+  local attempt=1
+
+  while (( attempt <= max_attempts )); do
+    if (( max_attempts > 1 )); then
+      log "调用 [${api_name}]: ${method} ${url} (第 ${attempt}/${max_attempts} 次)"
+    else
+      log "调用 [${api_name}]: ${method} ${url}"
+    fi
+
+    local curl_args=(-sS -w "\nHTTP_CODE:%{http_code}" -X "${method}" "${url}"
+      -H "Content-Type: application/json"
+      -H "Accept: application/json, text/plain, */*"
+      --connect-timeout 10 --max-time "${max_time}")
+
+    if [[ -n "${AUTH_TOKEN}" ]]; then
+      curl_args+=(-H "Authorization: Bearer ${AUTH_TOKEN}")
+    fi
+
+    if [[ -n "${body}" ]]; then
+      curl_args+=(--data "${body}")
+    fi
+
+    local result
+    result=$(curl "${curl_args[@]}" 2>&1 || echo "HTTP_CODE:000")
+
+    local http_code="" response=""
+    if [[ "$result" =~ HTTP_CODE:([0-9]{3}) ]]; then
+      http_code="${BASH_REMATCH[1]}"
+      response=$(echo "$result" | sed '/HTTP_CODE:/d')
+    else
+      http_code="000"
+      response="$result"
+    fi
+
+    API_RESPONSE="$response"
+    API_HTTP_CODE="$http_code"
+
+    # 成功或幂等
+    if [[ "$http_code" =~ ^2[0-9]{2}$ ]] || [[ "$http_code" == "409" ]]; then
+      return 0
+    fi
+
+    # 连接失败时重试
+    if [[ "$http_code" == "000" ]] && (( attempt < max_attempts )); then
+      log "连接失败，${RETRY_DELAY}秒后重试..."
+      sleep "${RETRY_DELAY}"
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    if (( attempt >= max_attempts )); then
+      return 1
+    fi
+
+    sleep "${RETRY_DELAY}"
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+########################################
+# Step 1: 登录 HiMarket
+########################################
+login_himarket() {
+  log "登录 HiMarket Admin..."
+
+  local body
+  body=$(jq -n \
+    --arg username "${ADMIN_USERNAME}" \
+    --arg password "${ADMIN_PASSWORD}" \
+    '{username: $username, password: $password}')
+
+  local attempt=1
+  while (( attempt <= MAX_RETRIES )); do
+    if call_himarket_api "管理员登录" "POST" "/api/v1/admins/login" "$body" 1; then
+      AUTH_TOKEN=$(echo "$API_RESPONSE" | jq -r '.data.access_token // empty' 2>/dev/null || echo "")
+      if [[ -z "${AUTH_TOKEN}" ]]; then
+        AUTH_TOKEN=$(echo "$API_RESPONSE" | jq -r '.data.token // .data.accessToken // empty' 2>/dev/null || echo "")
+      fi
+
+      if [[ -n "${AUTH_TOKEN}" ]]; then
+        log "HiMarket 登录成功"
+        return 0
+      fi
+    fi
+
+    if (( attempt < MAX_RETRIES )); then
+      log "登录失败，${RETRY_DELAY}秒后重试..."
+      sleep "${RETRY_DELAY}"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  err "HiMarket 登录失败"
+  return 1
+}
+
+########################################
+# Step 2: 注册 Nacos 实例（幂等）
+########################################
+register_nacos_instance() {
+  log "注册 Nacos 实例..."
+
+  local nacos_server_url="http://nacos.${NS}.svc.cluster.local:8848"
+
+  local body
+  body=$(jq -n \
+    --arg nacosName "default-nacos" \
+    --arg serverUrl "${nacos_server_url}" \
+    --arg username "nacos" \
+    --arg password "${NACOS_ADMIN_PASSWORD}" \
+    --arg description "Built-in Nacos instance" \
+    '{
+      nacosName: $nacosName,
+      serverUrl: $serverUrl,
+      username: $username,
+      password: $password,
+      description: $description
+    }')
+
+  call_himarket_api "创建Nacos实例" "POST" "/api/v1/nacos" "$body" 1 >/dev/null 2>&1 || true
+
+  # 查询获取 nacosId
+  local attempt=1
+  while (( attempt <= 3 )); do
+    call_himarket_api "查询Nacos实例" "GET" "/api/v1/nacos" "" 1 >/dev/null 2>&1 || true
+    NACOS_ID=$(echo "$API_RESPONSE" | jq -r '.data.content[0].nacosId // empty' 2>/dev/null || echo "")
+
+    if [[ -n "$NACOS_ID" ]]; then
+      log "Nacos 实例 ID: ${NACOS_ID}"
+      return 0
+    fi
+    sleep 3
+    attempt=$((attempt + 1))
+  done
+
+  err "无法获取 Nacos 实例 ID"
+  return 1
+}
+
+########################################
+# Step 3: 导入 Skills
+########################################
+import_skills() {
+  log "从 Nacos 导入 Skills..."
+
+  if call_himarket_api "导入Skills" "POST" "/api/v1/skills/import?nacosId=${NACOS_ID}&namespace=public" "" 1 120; then
+    SKILL_SUCCESS=$(echo "$API_RESPONSE" | jq -r '.data.successCount // 0' 2>/dev/null || echo "0")
+    SKILL_SKIPPED=$(echo "$API_RESPONSE" | jq -r '.data.skippedCount // 0' 2>/dev/null || echo "0")
+    log "Skills 导入完成: ${SKILL_SUCCESS} 成功, ${SKILL_SKIPPED} 跳过"
+    return 0
+  else
+    err "Skills 导入失败 (HTTP ${API_HTTP_CODE})"
+    return 1
+  fi
+}
+
+########################################
+# Step 4: 导入 Workers
+########################################
+import_workers() {
+  log "从 Nacos 导入 Workers..."
+
+  if call_himarket_api "导入Workers" "POST" "/api/v1/workers/import?nacosId=${NACOS_ID}&namespace=public" "" 1 120; then
+    WORKER_SUCCESS=$(echo "$API_RESPONSE" | jq -r '.data.successCount // 0' 2>/dev/null || echo "0")
+    WORKER_SKIPPED=$(echo "$API_RESPONSE" | jq -r '.data.skippedCount // 0' 2>/dev/null || echo "0")
+    log "Workers 导入完成: ${WORKER_SUCCESS} 成功, ${WORKER_SKIPPED} 跳过"
+    return 0
+  else
+    err "Workers 导入失败 (HTTP ${API_HTTP_CODE})"
+    return 1
+  fi
+}
+
+########################################
+# Step 5: 获取或创建 Portal
+########################################
+get_or_create_portal() {
+  local portal_name="${1:-demo}"
+
+  local body="{\"name\":\"${portal_name}\"}"
+  call_himarket_api "创建Portal" "POST" "/api/v1/portals" "$body" 1 >/dev/null 2>&1 || true
+
+  # 查询获取 portalId
+  local attempt=1 p_id=""
+  while (( attempt <= 3 )); do
+    call_himarket_api "查询Portal" "GET" "/api/v1/portals" "" 1 >/dev/null 2>&1 || true
+    p_id=$(echo "$API_RESPONSE" | jq -r '.data.content[]? // .[]? | select(.name=="'"${portal_name}"'") | .portalId' 2>/dev/null | head -1 || echo "")
+
+    if [[ -n "$p_id" ]]; then
+      echo "$p_id"
+      return 0
+    fi
+    sleep 3
+    attempt=$((attempt + 1))
+  done
+
+  return 1
+}
+
+########################################
+# Step 6: 发布产品到门户
+########################################
+publish_products_to_portal() {
+  local portal_id="$1"
+
+  log "获取 AGENT_SKILL 和 WORKER 产品列表..."
+
+  local product_ids=()
+
+  # 获取 AGENT_SKILL 产品
+  if call_himarket_api "查询Skills产品" "GET" "/api/v1/products?type=AGENT_SKILL&size=200" "" 1; then
+    local skill_ids
+    skill_ids=$(echo "$API_RESPONSE" | jq -r '.data.content[]?.productId // empty' 2>/dev/null || echo "")
+    if [[ -n "$skill_ids" ]]; then
+      while IFS= read -r pid; do
+        [[ -n "$pid" ]] && product_ids+=("$pid")
+      done <<< "$skill_ids"
+    fi
+  fi
+
+  # 获取 WORKER 产品
+  if call_himarket_api "查询Workers产品" "GET" "/api/v1/products?type=WORKER&size=200" "" 1; then
+    local worker_ids
+    worker_ids=$(echo "$API_RESPONSE" | jq -r '.data.content[]?.productId // empty' 2>/dev/null || echo "")
+    if [[ -n "$worker_ids" ]]; then
+      while IFS= read -r pid; do
+        [[ -n "$pid" ]] && product_ids+=("$pid")
+      done <<< "$worker_ids"
+    fi
+  fi
+
+  local total=${#product_ids[@]}
+  if (( total == 0 )); then
+    log "没有需要发布的产品"
+    return 0
+  fi
+
+  log "共 ${total} 个产品待发布到门户..."
+
+  local body
+  for pid in "${product_ids[@]}"; do
+    body="{\"portalId\":\"${portal_id}\"}"
+    if call_himarket_api "发布产品" "POST" "/api/v1/products/${pid}/publications" "$body" 1; then
+      if [[ "$API_HTTP_CODE" == "409" ]]; then
+        PUBLISH_SKIPPED=$((PUBLISH_SKIPPED + 1))
+      else
+        PUBLISH_SUCCESS=$((PUBLISH_SUCCESS + 1))
+      fi
+    else
+      PUBLISH_FAILED=$((PUBLISH_FAILED + 1))
+      log "产品 ${pid} 发布失败 (HTTP ${API_HTTP_CODE})"
+    fi
+  done
+}
+
+########################################
+# main
+########################################
+main() {
+  log ""
+  log "========================================"
+  log "  Nacos Skills/Workers 同步与发布"
+  log "========================================"
+  log ""
+
+  # 0. 检查依赖
+  check_dependencies
+
+  # 1. 解析服务地址
+  resolve_himarket_url
+
+  # 2. 登录 HiMarket
+  if ! login_himarket; then
+    err "HiMarket Admin 登录失败，终止同步"
+    exit 1
+  fi
+
+  # 3. 注册 Nacos 实例
+  if ! register_nacos_instance; then
+    err "Nacos 实例注册失败，终止同步"
+    exit 1
+  fi
+
+  # 4. 导入 Skills（失败不阻断）
+  import_skills || log "Skills 导入失败，继续执行..."
+
+  # 5. 导入 Workers（失败不阻断）
+  import_workers || log "Workers 导入失败，继续执行..."
+
+  # 6. 获取或创建 Portal
+  log "获取 Portal ID..."
+  PORTAL_ID=$(get_or_create_portal "demo")
+  if [[ -z "${PORTAL_ID}" ]]; then
+    err "无法获取 Portal ID，跳过产品发布"
+  else
+    log "Portal ID: ${PORTAL_ID}"
+
+    # 7. 发布产品到门户
+    publish_products_to_portal "${PORTAL_ID}"
+  fi
+
+  # 汇总
+  log ""
+  log "========================================"
+  log "  同步完成"
+  log "  Skills 导入:  ${SKILL_SUCCESS} 成功, ${SKILL_SKIPPED} 跳过"
+  log "  Workers 导入: ${WORKER_SUCCESS} 成功, ${WORKER_SKIPPED} 跳过"
+  log "  产品发布:     ${PUBLISH_SUCCESS} 成功, ${PUBLISH_SKIPPED} 跳过, ${PUBLISH_FAILED} 失败"
+  log "========================================"
+  log ""
+}
+
+main "$@"

--- a/deploy/helm/install.sh
+++ b/deploy/helm/install.sh
@@ -542,7 +542,7 @@ load_config() {
                MYSQL_STORAGE_CLASS MYSQL_STORAGE_SIZE SANDBOX_STORAGE_CLASS SANDBOX_STORAGE_SIZE \
                HIGRESS_INGRESS_CLASS HIMARKET_LANGUAGE \
                SKIP_HOOK_ERRORS \
-               SKIP_AI_MODEL_INIT AI_MODEL_COUNT; do
+               SKIP_AI_MODEL_INIT AI_MODEL_COUNT SKIP_NACOS_SYNC; do
         eval "local _val=\"\${${var}:-}\""
         if [[ -n "${_val}" ]]; then
             saved_vars="${saved_vars} ${var}='${_val}'"
@@ -799,7 +799,7 @@ interactive_config() {
 
     log ""
     log "$(msg section.basic)"
-    prompt NAMESPACE "Kubernetes namespace" "himarket"
+    prompt NAMESPACE "Kubernetes namespace" "himarket-system"
 
     log ""
     log "$(msg section.image)"


### PR DESCRIPTION
## 📝 Description

为 Docker 和 Helm 部署环境新增 post-ready 钩子，在 HiMarket 启动后自动从 Nacos 同步 Skills 和 Workers：

- 新增 `65-sync-nacos-market.sh` 钩子脚本（Docker 和 Helm 各一份）
- 钩子执行流程：登录 HiMarket → 注册 Nacos 实例 → 导入 Skills → 导入 Workers → 发布到门户
- 支持 `SKIP_NACOS_SYNC=true` 环境变量跳过同步
- 部署脚本中保存/加载 `SKIP_NACOS_SYNC` 配置
- Helm 部署默认命名空间从 `himarket` 改为 `himarket-system`
- 包含重试逻辑和执行汇总统计

## 🔗 Related Issues



## ✅ Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] All tests pass locally

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend, `npm run lint:fix` for frontend)
- [x] Code is self-reviewed
- [x] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

🤖 Generated with [Qoder][https://qoder.com]