### PR TITLE
fix: handle expired tokens on public pages and improve developer portal UX

### DIFF
--- a/himarket-web/himarket-frontend/src/hooks/useAuth.ts
+++ b/himarket-web/himarket-frontend/src/hooks/useAuth.ts
@@ -1,11 +1,36 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import { useNavigate } from "react-router-dom";
+
+/**
+ * 全局 auth 失效通知。
+ * 当 request 拦截器在公开页面检测到 401/403 并清除了过期 token 后，
+ * 通过 `notifyAuthInvalidated()` 通知所有 useAuth 消费者刷新状态。
+ */
+let authVersion = 0;
+const listeners = new Set<() => void>();
+
+export function notifyAuthInvalidated() {
+  authVersion++;
+  listeners.forEach((l) => l());
+}
+
+function subscribeAuth(callback: () => void) {
+  listeners.add(callback);
+  return () => { listeners.delete(callback); };
+}
+
+function getAuthSnapshot() {
+  return authVersion;
+}
 
 export function useAuth() {
   const navigate = useNavigate();
 
-  const token = useMemo(() => localStorage.getItem("access_token"), []);
-  const isLoggedIn = useMemo(() => !!token, [token]);
+  // 订阅 auth 失效事件，触发重新读取 token
+  useSyncExternalStore(subscribeAuth, getAuthSnapshot);
+
+  const token = localStorage.getItem("access_token");
+  const isLoggedIn = !!token;
 
   const login = useCallback(
     (returnUrl?: string) => {

--- a/himarket-web/himarket-frontend/src/lib/request.ts
+++ b/himarket-web/himarket-frontend/src/lib/request.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import type { AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { message } from 'antd';
 import qs from 'qs';
+import { notifyAuthInvalidated } from '../hooks/useAuth';
 
 export interface RespI<T> {
   code: string;
@@ -61,7 +62,11 @@ request.interceptors.response.use(
     switch (status) {
       case 401:
         if (isPublicPage()) {
-          // 公开页面静默处理，不跳转、不清除 Token
+          // 公开页面：如果有过期 token 则清除，并通知组件更新登录状态
+          if (localStorage.getItem('access_token')) {
+            localStorage.removeItem('access_token');
+            notifyAuthInvalidated();
+          }
           break;
         }
         message.error('未登录或登录已过期，请重新登录');
@@ -73,6 +78,10 @@ request.interceptors.response.use(
         break;
       case 403:
         if (isPublicPage()) {
+          if (localStorage.getItem('access_token')) {
+            localStorage.removeItem('access_token');
+            notifyAuthInvalidated();
+          }
           break;
         }
         localStorage.removeItem('access_token');

--- a/himarket-web/himarket-frontend/src/pages/Chat.tsx
+++ b/himarket-web/himarket-frontend/src/pages/Chat.tsx
@@ -42,6 +42,8 @@ function Chat() {
 
   // 从 location.state 接收选中的产品，或者加载默认第一个模型
   useEffect(() => {
+    if (!isLoggedIn) return;
+
     const state = location.state as { selectedProduct?: IProductDetail } | null;
     if (state?.selectedProduct) {
       setSelectedModel(state.selectedProduct);
@@ -68,7 +70,7 @@ function Chat() {
       };
       loadDefaultModel();
     }
-  }, [location, chatType]);
+  }, [location, chatType, isLoggedIn]);
 
   const handleSendMessage = async (content: string, mcps: IProductDetail[], enableWebSearch: boolean, modelMap: Map<string, IProductDetail>, attachments: IAttachment[] = []) => {
     if (!selectedModel) {

--- a/himarket-web/himarket-frontend/src/pages/SkillDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/SkillDetail.tsx
@@ -109,7 +109,7 @@ function SkillDetail() {
   const [selectedVersion, setSelectedVersion] = useState<string | undefined>();
   const [cliInfo, setCliInfo] = useState<SkillCliInfo | null>(null);
   const [selectedIde, setSelectedIde] = useState<IdeType>('qoder');
-  const [outputDir, setOutputDir] = useState<string>('./.qoder/skills');
+  const [outputDir, setOutputDir] = useState<string>('~/.qoder/skills');
 
   const handleDragStart = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -155,9 +155,10 @@ function SkillDetail() {
         }
 
         // Only show online (published) versions in frontend
-        const onlineVersions = (versionsRes?.code === "SUCCESS" && Array.isArray(versionsRes.data))
-          ? versionsRes.data.filter((v: SkillVersion) => v.status === "online")
+        const allVersions = (versionsRes?.code === "SUCCESS" && Array.isArray(versionsRes.data))
+          ? versionsRes.data
           : [];
+        const onlineVersions = allVersions.filter((v: SkillVersion) => v.status === "online");
         setVersions(onlineVersions);
 
         // Default to latest online version
@@ -166,6 +167,11 @@ function SkillDetail() {
 
         // Load file tree for the default version
         await loadVersionContent(defaultVersion);
+
+        // Fallback: if no online versions but product has document, use it as overview
+        if (onlineVersions.length === 0 && allVersions.length > 0 && productRes.data?.document) {
+          setOverviewContent(productRes.data.document);
+        }
       } catch (err) {
         console.error("API请求失败:", err);
         setError("加载失败，请稍后重试");


### PR DESCRIPTION
## 📝 Description

修复前端公开页面的过期 token 处理逻辑，并改善开发者门户用户体验：

- 公开页面收到 401/403 时清除过期 token，避免登录状态显示不一致
- 使用 `useSyncExternalStore` 实现响应式认证状态，token 变更时自动刷新 UI
- 新增 `notifyAuthInvalidated()` 机制广播 token 失效事件
- 修复 Chat 页面：未登录时跳过模型加载，避免无意义的 API 请求
- 修复 SkillDetail 页面：当没有上线版本时，回退显示产品文档作为概览
- 默认 Skill 安装目录从 `./.qoder/skills` 改为 `~/.qoder/skills`

## 🔗 Related Issues



## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] All tests pass locally

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend, `npm run lint:fix` for frontend)
- [x] Code is self-reviewed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

🤖 Generated with [Qoder][https://qoder.com]