### PR TITLE
fix: handle catch-all path variables in PublicAccessPathScanner

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/core/security/PublicAccessPathScanner.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/core/security/PublicAccessPathScanner.java
@@ -181,7 +181,9 @@ public class PublicAccessPathScanner implements ApplicationContextAware {
         if (!path.startsWith("/")) {
             path = "/" + path;
         }
-        // Replace path variables like {productId} with *
+        // Replace catch-all path variables like {*filePath} with **
+        path = path.replaceAll("\\{\\*[^}]+}", "**");
+        // Replace regular path variables like {productId} with *
         path = path.replaceAll("\\{[^}]+}", "*");
         return path;
     }


### PR DESCRIPTION
## 📝 Description

`PublicAccessPathScanner.normalizePath()` 将所有路径变量（包括 catch-all `{*filePath}`）统一替换为单段通配符 `*`。但在 Spring Security 的 `PathPatternParser` 中，`*` 只匹配单层路径段，不包含 `/`。

这导致 `@PublicAccess` 标记的 catch-all 端点（如 `GET /skills/{id}/files/{*filePath}`）被标准化为 `/skills/*/files/*`，无法匹配多层文件路径（如 `/skills/abc/files/src/App.tsx`），请求走到 `anyRequest().authenticated()` 返回 **403 Forbidden**。

**修复**：在替换普通路径变量之前，先将 catch-all 路径变量 `{*...}` 替换为 `**`（多段通配符）。

**复现**：
```bash
# 修复前：单层路径正常，多层路径 403
curl -s -w "%{http_code}" http://localhost:8080/skills/136/files/SKILL.md       # 200
curl -s -w "%{http_code}" http://localhost:8080/skills/136/files/src/test.md    # 403

# 修复后：均正常
curl -s -w "%{http_code}" http://localhost:8080/skills/136/files/SKILL.md       # 200
curl -s -w "%{http_code}" http://localhost:8080/skills/136/files/src/test.md    # 200
```

## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] Manual testing completed
- [x] All tests pass locally

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend)
- [x] Code is self-reviewed
- [x] No breaking changes

🤖 Generated with [Qoder][https://qoder.com]