### PR TITLE
fix: add init-data retry command, idempotent Nacos schema, and misc fixes

### DIFF
--- a/deploy/docker/install.sh
+++ b/deploy/docker/install.sh
@@ -18,19 +18,21 @@ exec > >(tee -a "${HIMARKET_LOG_FILE}") 2>&1
 
 # ── 全局标志 ──────────────────────────────────────────────────────────────────
 NON_INTERACTIVE="${NON_INTERACTIVE:-0}"
-ACTION="deploy"    # deploy | uninstall
+ACTION="deploy"    # deploy | uninstall | init-data
 
 # ── 解析命令行参数 ────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -n|--non-interactive) NON_INTERACTIVE=1; shift ;;
         --uninstall)          ACTION="uninstall"; shift ;;
+        --init-data)          ACTION="init-data"; shift ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo ""
             echo "Options:"
             echo "  -n, --non-interactive  跳过交互式提示，使用 ~/himarket-install.env / 默认值"
             echo "  --uninstall            卸载所有组件"
+            echo "  --init-data            重试所有初始化数据钩子（跳过服务部署，仅执行数据初始化）"
             echo "  -h, --help             显示帮助"
             exit 0
             ;;
@@ -942,6 +944,72 @@ uninstall_all() {
 }
 
 # =============================================================================
+# 重试初始化数据
+# =============================================================================
+
+init_data() {
+    log ""
+    log "=========================================="
+    log "  重试初始化数据（跳过服务部署）"
+    log "=========================================="
+    log ""
+
+    # 加载已保存的配置
+    load_config
+
+    if [[ ! -f "${ENV_FILE}" ]]; then
+        error "未找到配置文件 ${ENV_FILE}，请先运行 $0 完成部署"
+    fi
+
+    # 验证核心服务是否在运行
+    log "检查服务状态..."
+    local services_ok=true
+    for svc in mysql nacos himarket-server himarket-admin himarket-frontend; do
+        local cid
+        cid=$(docker_compose ps -q "${svc}" 2>/dev/null || true)
+        if [[ -z "$cid" ]]; then
+            warn "服务 ${svc} 未运行"
+            services_ok=false
+        else
+            local status
+            status=$(docker inspect -f '{{ .State.Status }}' "$cid" 2>/dev/null || echo "unknown")
+            if [[ "$status" != "running" ]]; then
+                warn "服务 ${svc} 状态异常: ${status}"
+                services_ok=false
+            fi
+        fi
+    done
+
+    if [[ "${services_ok}" != "true" ]]; then
+        warn "部分服务未运行，初始化数据可能失败"
+        if [[ "${NON_INTERACTIVE}" != "1" ]]; then
+            local answer=""
+            read -r -p "是否继续? [y/N] " answer
+            if [[ ! "${answer}" =~ ^[Yy]$ ]]; then
+                log "已取消"
+                exit 0
+            fi
+        fi
+    fi
+
+    # 执行 post_ready 钩子
+    log "开始执行数据初始化钩子..."
+    export SKIP_HOOK_ERRORS=true
+    if run_hooks "post_ready"; then
+        log ""
+        log "=========================================="
+        log "  所有初始化数据钩子执行成功"
+        log "=========================================="
+    else
+        warn ""
+        warn "=========================================="
+        warn "  部分钩子执行失败，请检查日志: ${HIMARKET_LOG_FILE}"
+        warn "=========================================="
+        exit 1
+    fi
+}
+
+# =============================================================================
 # 入口
 # =============================================================================
 
@@ -952,6 +1020,7 @@ main() {
             load_config
             uninstall_all
             ;;
+        init-data) init_data ;;
         *) error "Unknown action: ${ACTION}" ;;
     esac
 }

--- a/deploy/helm/install.sh
+++ b/deploy/helm/install.sh
@@ -19,19 +19,21 @@ exec > >(tee -a "${HIMARKET_LOG_FILE}") 2>&1
 
 # ── 全局标志 ──────────────────────────────────────────────────────────────────
 NON_INTERACTIVE="${NON_INTERACTIVE:-0}"
-ACTION="deploy"    # deploy | uninstall
+ACTION="deploy"    # deploy | uninstall | init-data
 
 # ── 解析命令行参数 ────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -n|--non-interactive) NON_INTERACTIVE=1; shift ;;
         --uninstall)          ACTION="uninstall"; shift ;;
+        --init-data)          ACTION="init-data"; shift ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo ""
             echo "Options:"
             echo "  -n, --non-interactive  跳过交互式提示，使用 ~/himarket-install.env / 默认值"
             echo "  --uninstall            卸载所有组件"
+            echo "  --init-data            重试所有初始化数据钩子（跳过服务部署，仅执行数据初始化）"
             echo "  -h, --help             显示帮助"
             exit 0
             ;;
@@ -1250,6 +1252,70 @@ uninstall_all() {
 }
 
 # =============================================================================
+# 重试初始化数据
+# =============================================================================
+
+init_data() {
+    log ""
+    log "=========================================="
+    log "  重试初始化数据（跳过服务部署）"
+    log "=========================================="
+    log ""
+
+    # 加载已保存的配置
+    load_config
+
+    if [[ ! -f "${ENV_FILE}" ]]; then
+        error "未找到配置文件 ${ENV_FILE}，请先运行 $0 完成部署"
+    fi
+
+    local ns="${NAMESPACE:-himarket}"
+
+    # 验证集群连接和核心 Pod 状态
+    log "检查集群和服务状态..."
+    command -v kubectl >/dev/null 2>&1 || error "$(msg deploy.missing_cmd "kubectl")"
+    kubectl cluster-info >/dev/null 2>&1 || error "无法连接到 Kubernetes 集群"
+
+    local services_ok=true
+    for deploy in himarket-server himarket-admin himarket-frontend nacos; do
+        local ready
+        ready=$(kubectl get deployment "${deploy}" -n "${ns}" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+        if [[ "${ready:-0}" -lt 1 ]]; then
+            warn "Deployment ${deploy} 未就绪 (readyReplicas=${ready:-0})"
+            services_ok=false
+        fi
+    done
+
+    if [[ "${services_ok}" != "true" ]]; then
+        warn "部分服务未就绪，初始化数据可能失败"
+        if [[ "${NON_INTERACTIVE}" != "1" ]]; then
+            local answer=""
+            read -r -p "是否继续? [y/N] " answer
+            if [[ ! "${answer}" =~ ^[Yy]$ ]]; then
+                log "已取消"
+                exit 0
+            fi
+        fi
+    fi
+
+    # 执行 post_ready 钩子
+    log "开始执行数据初始化钩子..."
+    export SKIP_HOOK_ERRORS=true
+    if run_hooks "post_ready"; then
+        log ""
+        log "=========================================="
+        log "  所有初始化数据钩子执行成功"
+        log "=========================================="
+    else
+        warn ""
+        warn "=========================================="
+        warn "  部分钩子执行失败，请检查日志: ${HIMARKET_LOG_FILE}"
+        warn "=========================================="
+        exit 1
+    fi
+}
+
+# =============================================================================
 # 入口
 # =============================================================================
 
@@ -1260,6 +1326,7 @@ main() {
             load_config
             uninstall_all
             ;;
+        init-data) init_data ;;
         *) error "Unknown action: ${ACTION}" ;;
     esac
 }

--- a/deploy/helm/nacos/sql/mysql-schema.sql
+++ b/deploy/helm/nacos/sql/mysql-schema.sql
@@ -17,7 +17,7 @@
 /******************************************/
 /*   表名称 = config_info                  */
 /******************************************/
-CREATE TABLE `config_info` (
+CREATE TABLE IF NOT EXISTS  `config_info` (
                                `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
                                `data_id` varchar(255) NOT NULL COMMENT 'data_id',
                                `group_id` varchar(128) DEFAULT NULL COMMENT 'group_id',
@@ -42,7 +42,7 @@ CREATE TABLE `config_info` (
 /******************************************/
 /*   表名称 = config_info  since 2.5.0                */
 /******************************************/
-CREATE TABLE `config_info_gray` (
+CREATE TABLE IF NOT EXISTS `config_info_gray` (
                                     `id` bigint unsigned NOT NULL AUTO_INCREMENT COMMENT 'id',
                                     `data_id` varchar(255) NOT NULL COMMENT 'data_id',
                                     `group_id` varchar(128) NOT NULL COMMENT 'group_id',
@@ -66,7 +66,7 @@ CREATE TABLE `config_info_gray` (
 /******************************************/
 /*   表名称 = config_tags_relation         */
 /******************************************/
-CREATE TABLE `config_tags_relation` (
+CREATE TABLE IF NOT EXISTS  `config_tags_relation` (
                                         `id` bigint(20) NOT NULL COMMENT 'id',
                                         `tag_name` varchar(128) NOT NULL COMMENT 'tag_name',
                                         `tag_type` varchar(64) DEFAULT NULL COMMENT 'tag_type',
@@ -82,7 +82,7 @@ CREATE TABLE `config_tags_relation` (
 /******************************************/
 /*   表名称 = group_capacity               */
 /******************************************/
-CREATE TABLE `group_capacity` (
+CREATE TABLE IF NOT EXISTS  `group_capacity` (
                                   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
                                   `group_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'Group ID，空字符表示整个集群',
                                   `quota` int(10) unsigned NOT NULL DEFAULT '0' COMMENT '配额，0表示使用默认值',
@@ -100,7 +100,7 @@ CREATE TABLE `group_capacity` (
 /******************************************/
 /*   表名称 = his_config_info              */
 /******************************************/
-CREATE TABLE `his_config_info` (
+CREATE TABLE IF NOT EXISTS  `his_config_info` (
                                    `id` bigint(20) unsigned NOT NULL COMMENT 'id',
                                    `nid` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'nid, 自增标识',
                                    `data_id` varchar(255) NOT NULL COMMENT 'data_id',
@@ -128,7 +128,7 @@ CREATE TABLE `his_config_info` (
 /******************************************/
 /*   表名称 = tenant_capacity              */
 /******************************************/
-CREATE TABLE `tenant_capacity` (
+CREATE TABLE IF NOT EXISTS  `tenant_capacity` (
                                    `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
                                    `tenant_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'Tenant ID',
                                    `quota` int(10) unsigned NOT NULL DEFAULT '0' COMMENT '配额，0表示使用默认值',
@@ -144,7 +144,7 @@ CREATE TABLE `tenant_capacity` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='租户容量信息表';
 
 
-CREATE TABLE `tenant_info` (
+CREATE TABLE IF NOT EXISTS  `tenant_info` (
                                `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
                                `kp` varchar(128) NOT NULL COMMENT 'kp',
                                `tenant_id` varchar(128) default '' COMMENT 'tenant_id',
@@ -158,19 +158,19 @@ CREATE TABLE `tenant_info` (
                                KEY `idx_tenant_id` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='tenant_info';
 
-CREATE TABLE `users` (
+CREATE TABLE IF NOT EXISTS  `users` (
                          `username` varchar(50) NOT NULL PRIMARY KEY COMMENT 'username',
                          `password` varchar(500) NOT NULL COMMENT 'password',
                          `enabled` boolean NOT NULL COMMENT 'enabled'
 );
 
-CREATE TABLE `roles` (
+CREATE TABLE IF NOT EXISTS  `roles` (
                          `username` varchar(50) NOT NULL COMMENT 'username',
                          `role` varchar(50) NOT NULL COMMENT 'role',
                          UNIQUE INDEX `idx_user_role` (`username` ASC, `role` ASC) USING BTREE
 );
 
-CREATE TABLE `permissions` (
+CREATE TABLE IF NOT EXISTS  `permissions` (
                                `role` varchar(50) NOT NULL COMMENT 'role',
                                `resource` varchar(128) NOT NULL COMMENT 'resource',
                                `action` varchar(8) NOT NULL COMMENT 'action',
@@ -181,7 +181,7 @@ CREATE TABLE `permissions` (
 /******************************************/
 /*   表名称 = pipeline_execution           */
 /******************************************/
-CREATE TABLE `pipeline_execution` (
+CREATE TABLE IF NOT EXISTS  `pipeline_execution` (
     `execution_id`  varchar(64)  NOT NULL COMMENT '执行ID',
     `resource_type` varchar(32)  NOT NULL COMMENT '资源类型',
     `resource_name` varchar(256) NOT NULL COMMENT '资源名称',
@@ -197,7 +197,7 @@ CREATE TABLE `pipeline_execution` (
 /******************************************/
 /*   表名称 = ai_resource                 */
 /******************************************/
-CREATE TABLE `ai_resource` (
+CREATE TABLE IF NOT EXISTS  `ai_resource` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
     `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
     `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
@@ -224,7 +224,7 @@ CREATE TABLE `ai_resource` (
 /******************************************/
 /*   表名称 = ai_resource_version         */
 /******************************************/
-CREATE TABLE `ai_resource_version` (
+CREATE TABLE IF NOT EXISTS  `ai_resource_version` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT 'id',
     `gmt_create` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
     `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',

--- a/himarket-server/src/main/java/com/alibaba/himarket/core/skill/SkillMdBuilder.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/core/skill/SkillMdBuilder.java
@@ -10,19 +10,29 @@ public final class SkillMdBuilder {
 
     private SkillMdBuilder() {}
 
+    private static final String FRONTMATTER_DELIMITER = "---";
+
     /**
      * 从 Skill 对象生成 SKILL.md 内容。
+     *
+     * <p>如果 Skill 的 skillMd 已包含 YAML frontmatter（以 --- 开头），
+     * 则直接返回原始内容，避免重复拼接 name/description。
      */
     public static String build(Skill skill) {
+        String skillMd = skill.getSkillMd();
+        if (skillMd != null && skillMd.stripLeading().startsWith(FRONTMATTER_DELIMITER)) {
+            return skillMd;
+        }
+
         StringBuilder sb = new StringBuilder();
-        sb.append("---\n");
+        sb.append(FRONTMATTER_DELIMITER).append("\n");
         sb.append("name: ").append(skill.getName() != null ? skill.getName() : "").append("\n");
         sb.append("description: ")
                 .append(skill.getDescription() != null ? skill.getDescription() : "")
                 .append("\n");
-        sb.append("---\n\n");
-        if (skill.getSkillMd() != null) {
-            sb.append(skill.getSkillMd());
+        sb.append(FRONTMATTER_DELIMITER).append("\n\n");
+        if (skillMd != null) {
+            sb.append(skillMd);
         }
         return sb.toString();
     }

--- a/himarket-web/himarket-frontend/src/pages/SkillDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/SkillDetail.tsx
@@ -592,7 +592,9 @@ function SkillDetail() {
                   </div>
                   <button
                     onClick={() => {
-                      const cmd = `npx @nacos-group/cli --host ${cliInfo.nacosHost} skill-get ${cliInfo.resourceName} -o ${outputDir}`;
+                      const quotedName = cliInfo.resourceName.includes(' ') ? `"${cliInfo.resourceName}"` : cliInfo.resourceName;
+                      const quotedDir = outputDir.includes(' ') ? `"${outputDir}"` : outputDir;
+                      const cmd = `npx @nacos-group/cli --host ${cliInfo.nacosHost} skill-get ${quotedName} -o ${quotedDir}`;
                       copyToClipboard(cmd).then(() => {
                         setCopied(true);
                         setTimeout(() => setCopied(false), 2000);
@@ -648,7 +650,7 @@ function SkillDetail() {
 
                 <div className="rounded-md bg-gray-100 border border-gray-200 px-3 py-2">
                   <code className="text-[12px] text-gray-700 break-all" style={{ fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace" }}>
-                    {`npx @nacos-group/cli --host ${cliInfo.nacosHost} skill-get ${cliInfo.resourceName} -o ${outputDir}`}
+                    {`npx @nacos-group/cli --host ${cliInfo.nacosHost} skill-get ${cliInfo.resourceName.includes(' ') ? `"${cliInfo.resourceName}"` : cliInfo.resourceName} -o ${outputDir.includes(' ') ? `"${outputDir}"` : outputDir}`}
                   </code>
                 </div>
               </div>

--- a/himarket-web/himarket-frontend/src/pages/WorkerDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/WorkerDetail.tsx
@@ -589,7 +589,8 @@ function WorkerDetail() {
                     </div>
                     <button
                       onClick={() => {
-                        const cmd = `npx @nacos-group/cli --host ${cliInfo.nacosHost} agentspec-get ${cliInfo.resourceName}`;
+                        const quotedName = cliInfo.resourceName.includes(' ') ? `"${cliInfo.resourceName}"` : cliInfo.resourceName;
+                        const cmd = `npx @nacos-group/cli --host ${cliInfo.nacosHost} agentspec-get ${quotedName}`;
                         copyToClipboard(cmd).then(() => {
                           setCopiedCmd(true);
                           setTimeout(() => setCopiedCmd(false), 2000);
@@ -602,7 +603,7 @@ function WorkerDetail() {
                   </div>
                   <div className="rounded-md bg-gray-100 border border-gray-200 px-3 py-2">
                     <code className="text-[12px] text-gray-700 break-all" style={{ fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace" }}>
-                      {`npx @nacos-group/cli --host ${cliInfo.nacosHost} agentspec-get ${cliInfo.resourceName}`}
+                      {`npx @nacos-group/cli --host ${cliInfo.nacosHost} agentspec-get ${cliInfo.resourceName.includes(' ') ? `"${cliInfo.resourceName}"` : cliInfo.resourceName}`}
                     </code>
                   </div>
                 </div>


### PR DESCRIPTION
## 📝 Description

- Add `--init-data` option to Docker and Helm install scripts for retrying data initialization hooks without redeploying services
- Change all `CREATE TABLE` to `CREATE TABLE IF NOT EXISTS` in Nacos `mysql-schema.sql` for idempotent execution
- Fix `SkillMdBuilder` to skip frontmatter generation when `skillMd` already contains YAML frontmatter (avoids duplicate name/description)
- Fix CLI command quoting in `SkillDetail` and `WorkerDetail` pages for resource names and output paths containing spaces

## 🔗 Related Issues

N/A

## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [x] Manual testing completed
- [x] All tests pass locally

## 📋 Checklist

- [x] Code is self-reviewed
- [x] No breaking changes (or migration guide provided)

🤖 Generated with [Qoder][https://qoder.com]