### PR TITLE
fix(deploy): add NACOS_USERNAME config to install scripts for Higress parity

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -24,6 +24,7 @@ SANDBOX_IMAGE=opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/sand
 
 # ========== 服务凭证 ==========
 # 首次安装时由 install.sh 自动生成随机值，升级时沿用已有值
+# NACOS_USERNAME=nacos
 # NACOS_ADMIN_PASSWORD=
 # HIGRESS_USERNAME=admin
 # HIGRESS_PASSWORD=

--- a/deploy/docker/hooks/post_ready.d/10-init-nacos-admin.sh
+++ b/deploy/docker/hooks/post_ready.d/10-init-nacos-admin.sh
@@ -11,6 +11,7 @@ if [[ -f "${ENV_FILE}" ]]; then
   set -a; . "${ENV_FILE}"; set +a
 fi
 
+NACOS_USERNAME="${NACOS_USERNAME:-nacos}"
 NACOS_ADMIN_PASSWORD="${NACOS_ADMIN_PASSWORD:-nacos}"
 
 log() { echo "[init-nacos-admin $(date +'%H:%M:%S')] $*"; }
@@ -64,7 +65,7 @@ while (( attempt <= max_attempts )); do
       log "请使用已有凭据登录 Nacos Console: http://${NACOS_HOST}:8848/nacos"
     else
       log "Nacos 管理员密码初始化成功！"
-      log "用户名: nacos"
+      log "用户名: ${NACOS_USERNAME}"
       log "密码: ${NACOS_ADMIN_PASSWORD}"
       log "访问地址: http://${NACOS_HOST}:8848/nacos"
     fi

--- a/deploy/docker/install.sh
+++ b/deploy/docker/install.sh
@@ -384,7 +384,7 @@ load_config() {
                MYSQL_IMAGE NACOS_IMAGE HIGRESS_IMAGE REDIS_IMAGE SANDBOX_IMAGE \
                MYSQL_ROOT_PASSWORD MYSQL_PASSWORD MYSQL_DATABASE MYSQL_USER \
                JWT_SECRET \
-               NACOS_ADMIN_PASSWORD HIGRESS_USERNAME HIGRESS_PASSWORD \
+               NACOS_USERNAME NACOS_ADMIN_PASSWORD HIGRESS_USERNAME HIGRESS_PASSWORD \
                ADMIN_USERNAME ADMIN_PASSWORD FRONT_USERNAME FRONT_PASSWORD \
                HIMARKET_LANGUAGE \
                SKIP_HOOK_ERRORS \
@@ -619,6 +619,7 @@ interactive_config() {
     # ─── 服务凭证（首次安装时已自动生成随机值） ───
     log ""
     log "$(msg section.credential)"
+    prompt NACOS_USERNAME "Nacos admin username" "nacos"
     prompt NACOS_ADMIN_PASSWORD "Nacos admin password" "${NACOS_ADMIN_PASSWORD:-}"
     prompt HIGRESS_USERNAME "Higress console username" "admin"
     prompt HIGRESS_PASSWORD "Higress console password" "${HIGRESS_PASSWORD:-}"
@@ -773,6 +774,7 @@ MYSQL_PASSWORD="${MYSQL_PASSWORD}"
 JWT_SECRET="${JWT_SECRET}"
 
 # ========== 服务凭证 ==========
+NACOS_USERNAME="${NACOS_USERNAME}"
 NACOS_ADMIN_PASSWORD="${NACOS_ADMIN_PASSWORD}"
 HIGRESS_USERNAME="${HIGRESS_USERNAME}"
 HIGRESS_PASSWORD="${HIGRESS_PASSWORD}"
@@ -897,7 +899,7 @@ show_result_panel() {
     log ""
     log "  Admin login:          ${ADMIN_USERNAME} / ${ADMIN_PASSWORD}"
     log "  Developer login:      ${FRONT_USERNAME} / ${FRONT_PASSWORD}"
-    log "  Nacos login:          nacos / ${NACOS_ADMIN_PASSWORD:-nacos}"
+    log "  Nacos login:          ${NACOS_USERNAME} / ${NACOS_ADMIN_PASSWORD:-nacos}"
     log "  Higress login:        ${HIGRESS_USERNAME} / ${HIGRESS_PASSWORD}"
     log ""
     if [[ "${SKIP_AI_MODEL_INIT:-true}" != "true" ]]; then

--- a/deploy/helm/.env.example
+++ b/deploy/helm/.env.example
@@ -30,6 +30,7 @@ HIGRESS_CHART_REF=higress.io/higress
 
 # ========== 服务凭证 ==========
 # 首次安装时由 install.sh 自动生成随机值，升级时沿用已有值
+# NACOS_USERNAME=nacos
 # NACOS_ADMIN_PASSWORD=
 # HIGRESS_USERNAME=admin
 # HIGRESS_PASSWORD=

--- a/deploy/helm/hooks/post_ready.d/10-init-nacos-admin.sh
+++ b/deploy/helm/hooks/post_ready.d/10-init-nacos-admin.sh
@@ -19,6 +19,7 @@ fi
 
 NS="${NAMESPACE:-himarket}"
 
+NACOS_USERNAME="${NACOS_USERNAME:-nacos}"
 NACOS_ADMIN_PASSWORD="${NACOS_ADMIN_PASSWORD:-nacos}"
 
 log() { echo "[init-nacos-admin $(date +'%H:%M:%S')] $*"; }
@@ -81,7 +82,7 @@ while (( attempt <= max_attempts )); do
       log "请使用已有凭据登录 Nacos Console: http://${NACOS_HOST}:8080/nacos"
     else
       log "Nacos 管理员密码初始化成功！"
-      log "用户名: nacos"
+      log "用户名: ${NACOS_USERNAME}"
       log "密码: ${NACOS_ADMIN_PASSWORD}"
       log "访问地址: http://${NACOS_HOST}:8080/nacos"
     fi

--- a/deploy/helm/install.sh
+++ b/deploy/helm/install.sh
@@ -539,7 +539,7 @@ load_config() {
                HIGRESS_REPO_NAME HIGRESS_REPO_URL HIGRESS_CHART_REF \
                MYSQL_ROOT_PASSWORD MYSQL_PASSWORD \
                JWT_SECRET \
-               NACOS_ADMIN_PASSWORD HIGRESS_USERNAME HIGRESS_PASSWORD \
+               NACOS_USERNAME NACOS_ADMIN_PASSWORD HIGRESS_USERNAME HIGRESS_PASSWORD \
                ADMIN_USERNAME ADMIN_PASSWORD FRONT_USERNAME FRONT_PASSWORD \
                MYSQL_STORAGE_CLASS MYSQL_STORAGE_SIZE SANDBOX_STORAGE_CLASS SANDBOX_STORAGE_SIZE \
                HIGRESS_INGRESS_CLASS HIMARKET_LANGUAGE \
@@ -775,6 +775,7 @@ interactive_config() {
         if [[ -z "${JWT_SECRET:-}" ]]; then
             JWT_SECRET="$(openssl rand -base64 32)"
         fi
+        NACOS_USERNAME="${NACOS_USERNAME:-nacos}"
         NACOS_ADMIN_PASSWORD="${NACOS_ADMIN_PASSWORD:-nacos}"
         HIGRESS_USERNAME="${HIGRESS_USERNAME:-admin}"
         HIGRESS_PASSWORD="${HIGRESS_PASSWORD:-admin}"
@@ -821,6 +822,7 @@ interactive_config() {
     # ─── 服务凭证（首次安装时已自动生成随机值） ───
     log ""
     log "$(msg section.credential)"
+    prompt NACOS_USERNAME "Nacos admin username" "nacos"
     prompt NACOS_ADMIN_PASSWORD "Nacos admin password" "${NACOS_ADMIN_PASSWORD:-}"
     prompt HIGRESS_USERNAME "Higress console username" "admin"
     prompt HIGRESS_PASSWORD "Higress console password" "${HIGRESS_PASSWORD:-}"
@@ -1006,6 +1008,7 @@ MYSQL_PASSWORD="${MYSQL_PASSWORD}"
 JWT_SECRET="${JWT_SECRET}"
 
 # ========== 服务凭证 ==========
+NACOS_USERNAME="${NACOS_USERNAME}"
 NACOS_ADMIN_PASSWORD="${NACOS_ADMIN_PASSWORD}"
 HIGRESS_USERNAME="${HIGRESS_USERNAME}"
 HIGRESS_PASSWORD="${HIGRESS_PASSWORD}"
@@ -1199,7 +1202,7 @@ show_result_panel() {
     log "║"
     log "║  Admin login:      ${ADMIN_USERNAME} / ${ADMIN_PASSWORD}"
     log "║  Developer login:  ${FRONT_USERNAME} / ${FRONT_PASSWORD}"
-    log "║  Nacos login:      ${NACOS_USERNAME:-nacos} / ${NACOS_ADMIN_PASSWORD}"
+    log "║  Nacos login:      ${NACOS_USERNAME} / ${NACOS_ADMIN_PASSWORD}"
     log "║  Higress login:    ${HIGRESS_USERNAME} / ${HIGRESS_PASSWORD}"
     log "║"
     if [[ "${SKIP_AI_MODEL_INIT:-true}" != "true" ]]; then


### PR DESCRIPTION
## 📝 Description

- Add `NACOS_USERNAME` variable (default `nacos`) to both Helm and Docker install scripts, making Nacos credential configuration symmetric with Higress which already has `HIGRESS_USERNAME`
- Changes include: saved_vars list, interactive prompt, non-interactive defaults, `.env` persistence, login display panel, init hooks, and `.env.example` files

## 🔗 Related Issues



## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] All tests pass locally

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend, `npm run lint:fix` for frontend)
- [x] Code is self-reviewed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

## 📊 Test Coverage



## 📚 Additional Notes

Before this change, Higress had both `HIGRESS_USERNAME` + `HIGRESS_PASSWORD` with prompt/default/persistence, while Nacos only had `NACOS_ADMIN_PASSWORD` with the username hardcoded as `nacos`. This made the configuration asymmetric and could confuse users.

🤖 Generated with [Qoder][https://qoder.com]