### PR TITLE
feat: support Nacos displayServerUrl and improve HiClaw download UX

### DIFF
--- a/himarket-bootstrap/src/main/resources/db/migration/V15__Add_nacos_display_server_url.sql
+++ b/himarket-bootstrap/src/main/resources/db/migration/V15__Add_nacos_display_server_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE nacos_instance ADD COLUMN display_server_url VARCHAR(256) DEFAULT NULL;

--- a/himarket-dal/src/main/java/com/alibaba/himarket/entity/NacosInstance.java
+++ b/himarket-dal/src/main/java/com/alibaba/himarket/entity/NacosInstance.java
@@ -65,6 +65,9 @@ public class NacosInstance extends BaseEntity {
     @Column(name = "secret_key", length = 256)
     private String secretKey;
 
+    @Column(name = "display_server_url", length = 256)
+    private String displayServerUrl;
+
     @Column(name = "description", length = 512)
     private String description;
 

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/nacos/CreateNacosParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/nacos/CreateNacosParam.java
@@ -47,4 +47,6 @@ public class CreateNacosParam implements InputConverter<NacosInstance> {
     private String secretKey;
 
     private String description;
+
+    private String displayServerUrl;
 }

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/nacos/UpdateNacosParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/nacos/UpdateNacosParam.java
@@ -50,4 +50,7 @@ public class UpdateNacosParam implements InputConverter<NacosInstance> {
 
     @Size(max = 512, message = "Description cannot exceed 512 characters")
     private String description;
+
+    @Size(max = 256, message = "Display server URL cannot exceed 256 characters")
+    private String displayServerUrl;
 }

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/nacos/NacosResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/nacos/NacosResult.java
@@ -33,6 +33,8 @@ public class NacosResult implements OutputConverter<NacosResult, NacosInstance> 
 
     private String serverUrl;
 
+    private String displayServerUrl;
+
     private Boolean isDefault;
 
     private String defaultNamespace;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
@@ -512,7 +512,12 @@ public class SkillServiceImpl implements SkillService {
                 return null;
             }
             return CliDownloadInfo.builder()
-                    .nacosHost(URLUtil.url(nacos.getServerUrl()).getHost())
+                    .nacosHost(
+                            URLUtil.url(
+                                            StrUtil.isNotBlank(nacos.getDisplayServerUrl())
+                                                    ? nacos.getDisplayServerUrl()
+                                                    : nacos.getServerUrl())
+                                    .getHost())
                     .resourceName(config.getSkillName())
                     .resourceType("skill")
                     .build();

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/WorkerServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/WorkerServiceImpl.java
@@ -600,7 +600,12 @@ public class WorkerServiceImpl implements WorkerService {
                 return null;
             }
             return CliDownloadInfo.builder()
-                    .nacosHost(URLUtil.url(nacos.getServerUrl()).getHost())
+                    .nacosHost(
+                            URLUtil.url(
+                                            StrUtil.isNotBlank(nacos.getDisplayServerUrl())
+                                                    ? nacos.getDisplayServerUrl()
+                                                    : nacos.getServerUrl())
+                                    .getHost())
                     .resourceName(config.getAgentSpecName())
                     .resourceType("worker")
                     .build();

--- a/himarket-web/himarket-admin/src/pages/NacosConsoles.tsx
+++ b/himarket-web/himarket-admin/src/pages/NacosConsoles.tsx
@@ -114,6 +114,7 @@ export default function NacosConsoles() {
     form.setFieldsValue({
       nacosName: record.nacosName,
       serverUrl: record.serverUrl,
+      displayServerUrl: record.displayServerUrl,
       username: record.username,
       password: record.password,
       accessKey: record.accessKey,
@@ -328,6 +329,10 @@ export default function NacosConsoles() {
             )}
           </Form.Item>
       {/* 命名空间字段已移除 */}
+
+          <Form.Item name="displayServerUrl" label="展示地址">
+            <Input placeholder="可选，用于前台下载命令展示的公网地址，如 http://nacos.example.com:8848" />
+          </Form.Item>
 
           {/* 用户名/密码改为非必填 */}
           <Form.Item name="username" label="用户名" rules={[]}>

--- a/himarket-web/himarket-admin/src/types/gateway.ts
+++ b/himarket-web/himarket-admin/src/types/gateway.ts
@@ -49,6 +49,7 @@ export interface NacosInstance {
   nacosId: string
   nacosName: string
   serverUrl: string
+  displayServerUrl?: string
   username: string
   password?: string
   accessKey?: string

--- a/himarket-web/himarket-frontend/src/pages/WorkerDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/WorkerDetail.tsx
@@ -248,6 +248,7 @@ function WorkerDetail() {
   const [copiedHttp, setCopiedHttp] = useState(false);
   const [cliInfo, setCliInfo] = useState<WorkerCliInfo | null>(null);
   const [mdRawMode, setMdRawMode] = useState(true);
+  const [hiclawPlatform, setHiclawPlatform] = useState<'unix' | 'windows'>('unix');
 
   const handleDownload = useCallback(() => {
     if (!workerProductId) return;
@@ -547,6 +548,55 @@ function WorkerDetail() {
               </Button>
             </div>
 
+            {/* HiClaw 安装 */}
+            {cliInfo && (
+              <div className="px-4 py-3" style={{ borderBottom: '1px solid #f0f0f0' }}>
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center gap-1.5">
+                    <CloudUploadOutlined className="text-gray-400 text-xs" />
+                    <span className="text-xs font-medium text-gray-500">安装到 HiClaw</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <button
+                      onClick={() => setHiclawPlatform('unix')}
+                      className={`text-xs px-1.5 py-0.5 rounded transition-colors ${hiclawPlatform === 'unix' ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-400 hover:text-gray-600'}`}
+                    >
+                      Linux / Mac
+                    </button>
+                    <button
+                      onClick={() => setHiclawPlatform('windows')}
+                      className={`text-xs px-1.5 py-0.5 rounded transition-colors ${hiclawPlatform === 'windows' ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-400 hover:text-gray-600'}`}
+                    >
+                      Windows
+                    </button>
+                    <button
+                      onClick={() => {
+                        const quotedName = cliInfo.resourceName.includes(' ') ? `"${cliInfo.resourceName}"` : cliInfo.resourceName;
+                        const cmd = hiclawPlatform === 'unix'
+                          ? `curl -fsSL https://higress.ai/hiclaw/import.sh | bash -s -- --nacos --host ${cliInfo.nacosHost} --name ${quotedName}`
+                          : `irm https://higress.ai/hiclaw/import.ps1 -OutFile import.ps1; .\\import.ps1 --nacos --host ${cliInfo.nacosHost} --name ${quotedName}`;
+                        copyToClipboard(cmd).then(() => {
+                          setCopiedHiclaw(true);
+                          setTimeout(() => setCopiedHiclaw(false), 2000);
+                        });
+                      }}
+                      className="text-xs text-gray-400 hover:text-gray-600 transition-colors ml-1"
+                    >
+                      {copiedHiclaw ? <CheckOutlined className="text-green-500" /> : <CopyOutlined />}
+                    </button>
+                  </div>
+                </div>
+                <div className="rounded-md bg-gray-100 border border-gray-200 px-3 py-2">
+                  <code className="text-[12px] text-gray-700 break-all" style={{ fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace" }}>
+                    {hiclawPlatform === 'unix'
+                      ? `curl -fsSL https://higress.ai/hiclaw/import.sh | bash -s -- --nacos --host ${cliInfo.nacosHost} --name ${cliInfo.resourceName.includes(' ') ? `"${cliInfo.resourceName}"` : cliInfo.resourceName}`
+                      : `irm https://higress.ai/hiclaw/import.ps1 -OutFile import.ps1; .\\import.ps1 --nacos --host ${cliInfo.nacosHost} --name ${cliInfo.resourceName.includes(' ') ? `"${cliInfo.resourceName}"` : cliInfo.resourceName}`
+                    }
+                  </code>
+                </div>
+              </div>
+            )}
+
             {/* HTTP 下载 */}
             {cliInfo && (
               <div className="px-4 py-3">
@@ -604,33 +654,6 @@ function WorkerDetail() {
                   <div className="rounded-md bg-gray-100 border border-gray-200 px-3 py-2">
                     <code className="text-[12px] text-gray-700 break-all" style={{ fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace" }}>
                       {`npx @nacos-group/cli --host ${cliInfo.nacosHost} agentspec-get ${cliInfo.resourceName.includes(' ') ? `"${cliInfo.resourceName}"` : cliInfo.resourceName}`}
-                    </code>
-                  </div>
-                </div>
-
-                {/* HiClaw 安装命令 */}
-                <div>
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="flex items-center gap-1.5">
-                      <CloudUploadOutlined className="text-gray-400 text-xs" />
-                      <span className="text-xs font-medium text-gray-500">安装到 HiClaw</span>
-                    </div>
-                    <button
-                      onClick={() => {
-                        const cmd = `bash /opt/hiclaw/scripts/lib/hiclaw-import.sh --nacos --host ${cliInfo.nacosHost} --name ${cliInfo.resourceName}`;
-                        copyToClipboard(cmd).then(() => {
-                          setCopiedHiclaw(true);
-                          setTimeout(() => setCopiedHiclaw(false), 2000);
-                        });
-                      }}
-                      className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
-                    >
-                      {copiedHiclaw ? <CheckOutlined className="text-green-500" /> : <CopyOutlined />}
-                    </button>
-                  </div>
-                  <div className="rounded-md bg-gray-100 border border-gray-200 px-3 py-2">
-                    <code className="text-[12px] text-gray-700 break-all" style={{ fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace" }}>
-                      {`bash /opt/hiclaw/scripts/lib/hiclaw-import.sh --nacos --host ${cliInfo.nacosHost} --name ${cliInfo.resourceName}`}
                     </code>
                   </div>
                 </div>


### PR DESCRIPTION
## 📝 Description

- Add `displayServerUrl` field to `NacosInstance` entity, allowing operators to configure a public-facing Nacos address for CLI download commands (falls back to `serverUrl` when not set)
- Update `SkillServiceImpl` and `WorkerServiceImpl` to prefer `displayServerUrl` when building CLI download info
- Add `displayServerUrl` input to admin Nacos console form
- Redesign WorkerDetail HiClaw install section with platform tabs (Linux/Mac vs Windows) and one-liner `curl`/`irm` commands instead of the previous local script path
- Add Flyway migration V15 for the new `display_server_url` column

## 🔗 Related Issues



## ✅ Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] All tests pass locally

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend, `npm run lint:fix` for frontend)
- [x] Code is self-reviewed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

## 📊 Test Coverage



## 📚 Additional Notes

This change requires database migration (V15). The `displayServerUrl` column is nullable — existing deployments will automatically fall back to `serverUrl` with no action needed.

🤖 Generated with [Qoder][https://qoder.com]