### PR TITLE
fix(deploy): improve install scripts upgrade mode and image management

### DIFF
--- a/deploy/docker/install.sh
+++ b/deploy/docker/install.sh
@@ -419,6 +419,10 @@ load_config() {
         set +a
     fi
 
+    # 2.5 清除配置文件中的镜像相关变量，确保每次都使用脚本内置最新默认值
+    unset HIMARKET_SERVER_IMAGE HIMARKET_ADMIN_IMAGE HIMARKET_FRONTEND_IMAGE \
+          MYSQL_IMAGE NACOS_IMAGE HIGRESS_IMAGE REDIS_IMAGE SANDBOX_IMAGE 2>/dev/null || true
+
     # 3. 恢复 export 变量（覆盖配置文件中的同名变量）
     if [[ -n "${saved_vars}" ]]; then
         eval "export ${saved_vars}"
@@ -602,7 +606,7 @@ interactive_config() {
         prompt HIMARKET_ADMIN_IMAGE "HiMarket Admin image" "${HIMARKET_ADMIN_IMAGE:-opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-admin:latest}"
         prompt HIMARKET_FRONTEND_IMAGE "HiMarket Frontend image" "${HIMARKET_FRONTEND_IMAGE:-opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-frontend:latest}"
         prompt MYSQL_IMAGE "MySQL image" "${MYSQL_IMAGE:-opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/mysql:latest}"
-        prompt NACOS_IMAGE "Nacos image" "${NACOS_IMAGE:-nacos-registry.cn-hangzhou.cr.aliyuncs.com/nacos/nacos-server:v3.2.0}"
+        prompt NACOS_IMAGE "Nacos image" "${NACOS_IMAGE:-nacos-registry.cn-hangzhou.cr.aliyuncs.com/nacos/nacos-server:v3.2.1-2026.03.30}"
         prompt HIGRESS_IMAGE "Higress image" "${HIGRESS_IMAGE:-higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/all-in-one:latest}"
         prompt REDIS_IMAGE "Redis image" "${REDIS_IMAGE:-higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/redis-stack-server:7.4.0-v3}"
         prompt SANDBOX_IMAGE "Sandbox image" "${SANDBOX_IMAGE:-opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/sandbox:latest}"
@@ -657,7 +661,7 @@ interactive_config() {
     prompt HIMARKET_ADMIN_IMAGE "HiMarket Admin image" "opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-admin:latest"
     prompt HIMARKET_FRONTEND_IMAGE "HiMarket Frontend image" "opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-frontend:latest"
     prompt MYSQL_IMAGE "MySQL image" "opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/mysql:latest"
-    prompt NACOS_IMAGE "Nacos image" "nacos-registry.cn-hangzhou.cr.aliyuncs.com/nacos/nacos-server:v3.2.0"
+    prompt NACOS_IMAGE "Nacos image" "nacos-registry.cn-hangzhou.cr.aliyuncs.com/nacos/nacos-server:v3.2.1-2026.03.30"
     prompt HIGRESS_IMAGE "Higress image" "higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/all-in-one:latest"
     prompt REDIS_IMAGE "Redis image" "higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/redis-stack-server:7.4.0-v3"
     prompt SANDBOX_IMAGE "Sandbox image" "opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/sandbox:latest"
@@ -823,15 +827,8 @@ DEPLOY_MODE="${DEPLOY_MODE}"
 # ========== 数据目录 ==========
 HIMARKET_DATA_DIR="${HIMARKET_DATA_DIR}"
 
-# ========== 镜像配置 ==========
-HIMARKET_SERVER_IMAGE="${HIMARKET_SERVER_IMAGE}"
-HIMARKET_ADMIN_IMAGE="${HIMARKET_ADMIN_IMAGE}"
-HIMARKET_FRONTEND_IMAGE="${HIMARKET_FRONTEND_IMAGE}"
-MYSQL_IMAGE="${MYSQL_IMAGE}"
-NACOS_IMAGE="${NACOS_IMAGE}"
-HIGRESS_IMAGE="${HIGRESS_IMAGE}"
-REDIS_IMAGE="${REDIS_IMAGE}"
-SANDBOX_IMAGE="${SANDBOX_IMAGE}"
+# 注意：镜像配置不保存到本文件，
+# 每次安装始终使用 install.sh 脚本内置的最新默认值。
 
 # ========== 数据库密码 ==========
 MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD}"
@@ -927,8 +924,16 @@ deploy_all() {
     log "Docker Compose profiles: ${profiles}"
 
     # 6. 启动所有服务
-    log "启动 Docker Compose 服务..."
-    docker_compose up -d
+    if [[ "${DEPLOY_MODE}" == "upgrade" ]]; then
+        # 升级模式：显式拉取最新镜像，确保 latest 等 tag 获取到远端最新版本
+        log "拉取最新镜像..."
+        docker_compose pull
+        log "使用最新镜像重新创建服务..."
+        docker_compose up -d
+    else
+        log "启动 Docker Compose 服务..."
+        docker_compose up -d
+    fi
 
     # 7. 等待核心服务就绪
     log "等待核心服务启动..."
@@ -942,10 +947,14 @@ deploy_all() {
     wait_service "himarket-admin" 120
     wait_service "himarket-frontend" 120
 
-    # 8. 执行 post_ready 钩子
-    log "所有容器已就绪，开始执行数据初始化..."
-    export SKIP_HOOK_ERRORS=true
-    run_hooks "post_ready" || warn "部分钩子执行失败，请检查日志"
+    # 8. 首次安装/重新安装：执行一次性初始化步骤
+    if [[ "${DEPLOY_MODE}" != "upgrade" ]]; then
+        log "所有容器已就绪，开始执行数据初始化..."
+        export SKIP_HOOK_ERRORS=true
+        run_hooks "post_ready" || warn "部分钩子执行失败，请检查日志"
+    else
+        log "升级完成，跳过初始化钩子（如需重新初始化数据，请使用 --init-data）"
+    fi
 
     # 9. 展示结果面板
     show_result_panel
@@ -960,7 +969,7 @@ show_result_panel() {
     log ""
     log "  HiMarket Admin:       http://localhost:5174"
     log "  HiMarket Frontend:    http://localhost:5173"
-    log "  Nacos Console:        http://localhost:8848/nacos"
+    log "  Nacos Console:        http://localhost:8080"
     log "  Higress Console:      http://localhost:8001"
     log "  HiMarket Server API:  http://localhost:8081"
     log ""

--- a/deploy/helm/install.sh
+++ b/deploy/helm/install.sh
@@ -571,6 +571,11 @@ load_config() {
         set +a
     fi
 
+    # 2.5 清除配置文件中的镜像/版本相关变量，确保每次都使用脚本内置最新默认值
+    unset HIMARKET_HUB HIMARKET_IMAGE_TAG HIMARKET_MYSQL_IMAGE_TAG \
+          NACOS_VERSION NACOS_IMAGE_REGISTRY NACOS_IMAGE_REPOSITORY \
+          HIGRESS_REPO_NAME HIGRESS_REPO_URL HIGRESS_CHART_REF 2>/dev/null || true
+
     # 3. 恢复 export 变量（覆盖配置文件中的同名变量）
     if [[ -n "${saved_vars}" ]]; then
         eval "export ${saved_vars}"
@@ -758,9 +763,9 @@ interactive_config() {
         log "$(msg install.upgrade_image_only)"
         log ""
         log "$(msg section.image)"
-        prompt HIMARKET_IMAGE_TAG "HiMarket image tag" "${HIMARKET_IMAGE_TAG:-latest}"
-        prompt HIMARKET_MYSQL_IMAGE_TAG "MySQL image tag" "${HIMARKET_MYSQL_IMAGE_TAG:-latest}"
-        prompt NACOS_VERSION "Nacos version" "${NACOS_VERSION:-v3.2.0}"
+        prompt HIMARKET_IMAGE_TAG "HiMarket image tag" "latest"
+        prompt HIMARKET_MYSQL_IMAGE_TAG "MySQL image tag" "latest"
+        prompt NACOS_VERSION "Nacos version" "v3.2.1-2026.03.30"
 
         # 其他配置沿用已有值（从配置文件加载）
         # 注意：回退默认值保留旧版硬编码值，仅用于兼容 env 文件缺失的已有部署
@@ -808,7 +813,7 @@ interactive_config() {
     prompt HIMARKET_HUB "HiMarket image hub" "opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group"
     prompt HIMARKET_IMAGE_TAG "HiMarket image tag" "latest"
     prompt HIMARKET_MYSQL_IMAGE_TAG "MySQL image tag" "latest"
-    prompt NACOS_VERSION "Nacos version" "v3.2.0"
+    prompt NACOS_VERSION "Nacos version" "v3.2.1-2026.03.30"
     prompt NACOS_IMAGE_REGISTRY "Nacos image registry" "nacos-registry.cn-hangzhou.cr.aliyuncs.com"
     prompt NACOS_IMAGE_REPOSITORY "Nacos image repository" "nacos/nacos-server"
 
@@ -986,18 +991,8 @@ DEPLOY_MODE="${DEPLOY_MODE}"
 # ========== 基础配置 ==========
 NAMESPACE="${NAMESPACE}"
 
-# ========== 镜像配置 ==========
-HIMARKET_HUB="${HIMARKET_HUB}"
-HIMARKET_IMAGE_TAG="${HIMARKET_IMAGE_TAG}"
-HIMARKET_MYSQL_IMAGE_TAG="${HIMARKET_MYSQL_IMAGE_TAG}"
-NACOS_VERSION="${NACOS_VERSION}"
-NACOS_IMAGE_REGISTRY="${NACOS_IMAGE_REGISTRY}"
-NACOS_IMAGE_REPOSITORY="${NACOS_IMAGE_REPOSITORY}"
-
-# ========== Helm 仓库 ==========
-HIGRESS_REPO_NAME="${HIGRESS_REPO_NAME}"
-HIGRESS_REPO_URL="${HIGRESS_REPO_URL}"
-HIGRESS_CHART_REF="${HIGRESS_CHART_REF}"
+# 注意：镜像配置 / Helm 仓库配置不保存到本文件，
+# 每次安装始终使用 install.sh 脚本内置的最新默认值。
 
 # ========== 数据库密码 ==========
 MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD}"
@@ -1127,12 +1122,27 @@ deploy_all() {
         --set "sandbox.persistence.size=${SANDBOX_STORAGE_SIZE}" \
         --set "server.jwtSecret=${JWT_SECRET}"
 
-    # 6.1 等待 HiMarket 核心组件就绪
+    # 6.1 升级模式：tag 不变（如 latest）时 helm upgrade 不会触发 rollout，
+    #     需要显式 rollout restart 让 imagePullPolicy: Always 生效拉取最新镜像
+    if [[ "${DEPLOY_MODE}" == "upgrade" ]]; then
+        if [[ "${HIMARKET_IMAGE_TAG}" == "latest" ]]; then
+            log "重启 HiMarket 组件以拉取最新 latest 镜像..."
+            kubectl rollout restart deployment himarket-server himarket-admin himarket-frontend -n "${NS}"
+        fi
+        if [[ "${HIMARKET_MYSQL_IMAGE_TAG}" == "latest" ]]; then
+            log "重启 MySQL 以拉取最新 latest 镜像..."
+            kubectl rollout restart statefulset mysql -n "${NS}" 2>/dev/null || true
+        fi
+        # sandbox 在 values.yaml 中默认使用 latest tag，始终重启
+        kubectl rollout restart deployment sandbox-shared -n "${NS}" 2>/dev/null || true
+    fi
+
+    # 6.2 等待 HiMarket 核心组件就绪
     wait_rollout "${NS}" "deployment" "himarket-server" 300
     wait_rollout "${NS}" "deployment" "himarket-admin" 300
     wait_rollout "${NS}" "deployment" "himarket-frontend" 300
 
-    # 7. 等待 MySQL Pod 就绪 + 初始化 Nacos 数据库
+    # 7. 同步 Nacos 数据库 schema（幂等，确保升级后 schema 与新版本一致）
     init_nacos_db_in_cluster "${NS}" "${MYSQL_ROOT_PASSWORD}" "${NACOS_DB_NAME}"
 
     # 8. 部署 Nacos
@@ -1149,6 +1159,12 @@ deploy_all() {
         --set "image.repository=${NACOS_IMAGE_REPOSITORY}" \
         --set "image.tag=${NACOS_VERSION}"
 
+    # 8.1 升级模式：Nacos 使用 latest 镜像时强制重启
+    if [[ "${DEPLOY_MODE}" == "upgrade" && "${NACOS_VERSION}" == "latest" ]]; then
+        log "重启 Nacos 以拉取最新 latest 镜像..."
+        kubectl rollout restart deployment nacos -n "${NS}" 2>/dev/null || true
+    fi
+
     wait_rollout "${NS}" "deployment" "nacos" 900
 
     # 9. 部署 Higress
@@ -1163,15 +1179,20 @@ deploy_all() {
     wait_rollout "${NS}" "deployment" "higress-gateway" 900
     wait_rollout "${NS}" "deployment" "higress-controller" 600
 
-    # 10. 配置 Higress MCP Redis
-    update_higress_mcp_redis "${NS}" || warn "mcpServer 配置更新失败，请手动检查"
+    # 10. 首次安装/重新安装：执行一次性初始化步骤
+    if [[ "${DEPLOY_MODE}" != "upgrade" ]]; then
+        # 配置 Higress MCP Redis
+        update_higress_mcp_redis "${NS}" || warn "mcpServer 配置更新失败，请手动检查"
 
-    # 11. 执行 post_ready 钩子（允许单个 hook 失败后继续执行后续 hook）
-    log "所有组件部署就绪，开始执行数据初始化..."
-    export SKIP_HOOK_ERRORS=true
-    run_hooks "post_ready" || warn "部分钩子执行失败，请检查日志"
+        # 执行 post_ready 钩子（允许单个 hook 失败后继续执行后续 hook）
+        log "所有组件部署就绪，开始执行数据初始化..."
+        export SKIP_HOOK_ERRORS=true
+        run_hooks "post_ready" || warn "部分钩子执行失败，请检查日志"
+    else
+        log "升级完成，跳过初始化钩子（如需重新初始化数据，请使用 --init-data）"
+    fi
 
-    # 12. 展示结果面板
+    # 11. 展示结果面板
     show_result_panel "${NS}"
 }
 
@@ -1196,7 +1217,7 @@ show_result_panel() {
     log "║"
     log "║  Frontend:         http://${frontend_ip}"
     log "║  Admin:            http://${admin_ip}"
-    log "║  Nacos:            http://${nacos_ip}:8848/nacos"
+    log "║  Nacos:            http://${nacos_ip}:8080"
     log "║  Higress Console:  http://${higress_ip}:${higress_port}"
     log "║"
     log "║  Admin login:      ${ADMIN_USERNAME} / ${ADMIN_PASSWORD}"


### PR DESCRIPTION
## 📝 Description

改进 Docker 和 Helm 两个安装脚本的升级模式和镜像管理逻辑：

- 加载配置时清除镜像相关变量，确保每次安装都使用脚本内置的最新默认值，避免旧配置文件中的过期镜像版本
- 升级 Nacos 默认版本从 v3.2.0 到 v3.2.1-2026.03.30
- 不再将镜像配置保存到 env 文件，防止升级时使用过期版本
- Docker：升级模式下先 `docker compose pull` 拉取最新镜像再重建服务
- Helm：升级模式下对 latest tag 的 deployment 执行 `rollout restart`，确保拉取到最新镜像
- 升级模式下跳过 `post_ready` 初始化钩子（数据已在首次安装时初始化）
- 修正 Nacos Console URL 从 `:8848/nacos` 到 `:8080`

## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [x] Performance improvement
- [x] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [x] Manual testing completed
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests pass locally

## 📋 Checklist

- [x] Code is self-reviewed
- [x] Comments added for complex code
- [x] No breaking changes (or migration guide provided)

🤖 Generated with [Qoder][https://qoder.com]