### PR TITLE
fix(hicoding): 修复PRE 路径类型不归一化及 sidecar 会话 reattach 校验缺失

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/ModelEndpointResolver.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/ModelEndpointResolver.java
@@ -162,7 +162,7 @@ public class ModelEndpointResolver {
     }
 
     /**
-     * 判断路径类型是否为前缀匹配（Higress 的 Prefix/Pre 均视为前缀匹配）。
+     * 判断路径类型是否为前缀匹配（Higress 返回的 Prefix/Pre 均视为前缀匹配）。
      */
     private static boolean isPrefixType(String pathType) {
         return "Prefix".equalsIgnoreCase(pathType) || "Pre".equalsIgnoreCase(pathType);

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/ModelEndpointResolver.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/ModelEndpointResolver.java
@@ -43,7 +43,7 @@ public class ModelEndpointResolver {
             return path;
         }
 
-        if ("Prefix".equalsIgnoreCase(pathType)) {
+        if (isPrefixType(pathType)) {
             return ensureVersionPrefix(path, protocol);
         }
 
@@ -75,7 +75,7 @@ public class ModelEndpointResolver {
             return path;
         }
 
-        if ("Prefix".equalsIgnoreCase(pathType)) {
+        if (isPrefixType(pathType)) {
             String base = ensureVersionPrefix(path, protocol);
             return base + getEndpointSuffix(protocol);
         }
@@ -159,5 +159,12 @@ public class ModelEndpointResolver {
             return path.substring(0, path.length() - 1);
         }
         return path;
+    }
+
+    /**
+     * 判断路径类型是否为前缀匹配（Higress 的 Prefix/Pre 均视为前缀匹配）。
+     */
+    private static boolean isPrefixType(String pathType) {
+        return "Prefix".equalsIgnoreCase(pathType) || "Pre".equalsIgnoreCase(pathType);
     }
 }

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxHttpClient.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxHttpClient.java
@@ -193,6 +193,26 @@ public class SandboxHttpClient {
     // ===== 内部 HTTP 调用方法 =====
 
     /**
+     * 验证 sidecar 中是否存在指定会话。
+     *
+     * <p>调用 Sidecar GET /sessions/{sessionId}，检查会话是否仍然有效。
+     * 任何异常（连接超时、网络错误等）均视为会话不存在。
+     *
+     * @param baseUrl   Sidecar 基础 URL
+     * @param sessionId sidecar 会话 ID
+     * @return true 表示会话存在，false 表示不存在或请求失败
+     */
+    public boolean sessionExists(String baseUrl, String sessionId) {
+        try {
+            String url = baseUrl + "/sessions/" + sessionId;
+            HttpResponse<String> response = doGet(url, HEALTH_CHECK_TIMEOUT);
+            return response.statusCode() == 200;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
      * 发送 POST 请求（JSON body）。
      * 统一处理 InterruptedException：恢复中断标志 + 包装为 IOException。
      */

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/HiCodingWebSocketHandler.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/HiCodingWebSocketHandler.java
@@ -5,6 +5,7 @@ import com.alibaba.himarket.config.AcpProperties.CliProviderConfig;
 import com.alibaba.himarket.service.hicoding.runtime.RemoteRuntimeAdapter;
 import com.alibaba.himarket.service.hicoding.runtime.RuntimeAdapter;
 import com.alibaba.himarket.service.hicoding.runtime.RuntimeConfig;
+import com.alibaba.himarket.service.hicoding.sandbox.SandboxHttpClient;
 import com.alibaba.himarket.service.hicoding.sandbox.SandboxInfo;
 import com.alibaba.himarket.service.hicoding.sandbox.SandboxType;
 import com.alibaba.himarket.service.hicoding.session.CliSessionConfig;
@@ -60,6 +61,7 @@ public class HiCodingWebSocketHandler extends TextWebSocketHandler {
     private final HiCodingMessageRouter messageRouter;
     private final HiCodingConnectionManager connectionManager;
     private final WebSocketPingScheduler pingScheduler;
+    private final SandboxHttpClient sandboxHttpClient;
 
     /** 异步初始化线程池（有界） */
     private final ExecutorService podInitExecutor =
@@ -82,13 +84,15 @@ public class HiCodingWebSocketHandler extends TextWebSocketHandler {
             SessionInitializer sessionInitializer,
             HiCodingMessageRouter messageRouter,
             HiCodingConnectionManager connectionManager,
-            WebSocketPingScheduler pingScheduler) {
+            WebSocketPingScheduler pingScheduler,
+            SandboxHttpClient sandboxHttpClient) {
         this.properties = properties;
         this.objectMapper = objectMapper;
         this.sessionInitializer = sessionInitializer;
         this.messageRouter = messageRouter;
         this.connectionManager = connectionManager;
         this.pingScheduler = pingScheduler;
+        this.sandboxHttpClient = sandboxHttpClient;
     }
 
     @PreDestroy
@@ -414,6 +418,18 @@ public class HiCodingWebSocketHandler extends TextWebSocketHandler {
             throw new RuntimeException(
                     "Sidecar connection closed immediately after reattach,"
                             + " session may have expired on sidecar side");
+        }
+
+        // 通过 REST API 验证 sidecar 会话是否真正存在
+        // sidecar 对任意 sessionId 都接受 WebSocket 连接，即使会话已删除
+        String sidecarBaseUrl =
+                "http://"
+                        + properties.getRemote().getHost()
+                        + ":"
+                        + properties.getRemote().getPort();
+        if (!sandboxHttpClient.sessionExists(sidecarBaseUrl, detached.sidecarSessionId())) {
+            throw new RuntimeException(
+                    "Sidecar session no longer exists: " + detached.sidecarSessionId());
         }
 
         if (!session.isOpen()) {


### PR DESCRIPTION
  ## 📝 Description

  修复 HiCoding 功能在使用时提示 `-32603 Internal error: 404 status code (no body)` 的问题。

  本次改动包含两个修复：

  **1. ModelEndpointResolver: 支持 Higress PRE 路径类型**
  - Higress 路由匹配类型 `PRE` 在语义上等同于 `Prefix`（前缀匹配），但 `resolveBaseUrlPath` 和 `resolveEndpointPath` 只处理了 `Prefix`，未处理 `PRE`
  - 当路由类型为 `PRE` 时，`/v1/chat/completions` 等完整端点路径不会被去除 `/chat/completions` 后缀，导致 baseUrl 变为 `/v1/chat/completions`
  - CLI（如 qwen-code）的 OpenAI SDK 会在 baseUrl 后再拼 `/chat/completions`，路径双拼导致 404
  - 新增 `isPrefixType()` 方法统一判断前缀匹配类型（`Prefix` 和 `PRE`）

  **2. HiCodingWebSocketHandler: reattach 时校验 sidecar 会话有效性**
  - Sidecar 的 WebSocket 端点对任意 sessionId 都会接受连接，即使会话已删除或过期
  - 后端在 reattach 时仅检查 `isAlive()`（WebSocket 连接是否存活），误判为会话有效
  - 实际连接到已死的旧进程，后续请求全部失败，且阻止了正常的重新初始化流程
  - 新增 `SandboxHttpClient.sessionExists()` 方法，通过 `GET /sessions/{id}` REST API 验证会话是否真正存在
  - 会话不存在时抛出异常，回退到完整初始化流程

  ## ✅ Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## 🧪 Testing

  - [x] Manual testing completed
  - [x] All tests pass locally

  手动测试验证：
  - 本地启动后端，配置 Higress PRE 路由类型，验证 `resolveBaseUrlPath("/v1/chat/completions", "PRE", ["OpenAI/V1"])` 正确返回 `/v1`
  - Docker 环境中删除 sidecar 旧会话后，验证后端 reattach 失败并正确回退到完整初始化
  - 端到端验证 HiCoding 功能可正常使用，不再出现 404 错误
  - 编译通过（`mvn compile -pl himarket-server -am -DskipTests`）
