### PR TITLE
fix: restrict batch import by gateway type and product type compatibility

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/HigressOperator.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/HigressOperator.java
@@ -116,7 +116,7 @@ public class HigressOperator extends GatewayOperator<HigressClient> {
 
     @Override
     public PageResult<AgentAPIResult> fetchAgentAPIs(Gateway gateway, int page, int size) {
-        return null;
+        return PageResult.of(Collections.emptyList(), page, size, 0);
     }
 
     @Override

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/ProductServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/ProductServiceImpl.java
@@ -1546,7 +1546,27 @@ public class ProductServiceImpl implements ProductService {
                         ErrorCode.INVALID_REQUEST,
                         "Gateway ID is required when source type is GATEWAY");
             }
-            gatewayService.getGateway(param.getGatewayId());
+            GatewayResult gateway = gatewayService.getGateway(param.getGatewayId());
+
+            // Higress gateway only supports MCP_SERVER batch import
+            if (gateway.getGatewayType().isHigress()) {
+                if (param.getProductType() == ProductType.REST_API) {
+                    throw new BusinessException(
+                            ErrorCode.INVALID_REQUEST,
+                            "Higress gateway does not support REST API batch import");
+                }
+                if (param.getProductType() == ProductType.AGENT_API) {
+                    throw new BusinessException(
+                            ErrorCode.INVALID_REQUEST,
+                            "Higress gateway does not support Agent API batch import");
+                }
+                if (param.getProductType() == ProductType.MODEL_API) {
+                    throw new BusinessException(
+                            ErrorCode.INVALID_REQUEST,
+                            "Higress gateway does not support Model API batch import yet. Higress"
+                                + " AI routes do not contain real model IDs required by HiMarket");
+                }
+            }
 
         } else if (param.getSourceType().isNacos()) {
             if (StrUtil.isBlank(param.getNacosId())) {
@@ -1556,10 +1576,14 @@ public class ProductServiceImpl implements ProductService {
             }
             nacosService.getNacosInstance(param.getNacosId());
 
-            // Nacos does not support MODEL_API
+            // Nacos does not support MODEL_API or REST_API
             if (param.getProductType() == ProductType.MODEL_API) {
                 throw new BusinessException(
                         ErrorCode.INVALID_REQUEST, "Nacos source does not support MODEL_API type");
+            }
+            if (param.getProductType() == ProductType.REST_API) {
+                throw new BusinessException(
+                        ErrorCode.INVALID_REQUEST, "Nacos source does not support REST_API type");
             }
         }
     }

--- a/himarket-web/himarket-admin/src/components/api-product/ImportProductsModal.tsx
+++ b/himarket-web/himarket-admin/src/components/api-product/ImportProductsModal.tsx
@@ -9,7 +9,7 @@ interface ImportProductsModalProps {
   visible: boolean;
   onCancel: () => void;
   onSuccess: () => void;
-  productType: 'REST_API' | 'MCP_SERVER' | 'AGENT_SKILL' | 'WORKER' | 'AGENT_API' | 'MODEL_API';
+  productType: 'REST_API' | 'MCP_SERVER' | 'AGENT_API' | 'MODEL_API';
 }
 
 interface ServiceItem {
@@ -68,18 +68,31 @@ export default function ImportProductsModal({
   const pageSize = 500; // 每次从后端加载的服务数量上限
 
   // 判断当前产品类型支持的数据源
-  // REST_API, MODEL_API: 仅支持 Gateway
-  // MCP_SERVER, AGENT_API: 支持 Gateway 和 Nacos
-  // AGENT_SKILL, WORKER: 不支持此界面导入
+  // Higress 网关仅支持 MCP_SERVER 批量导入
+  // REST_API, MODEL_API: 仅支持 AI 网关
+  // MCP_SERVER, AGENT_API: 支持 AI 网关和 Nacos
   const supportsNacos =
     productType === 'MCP_SERVER' ||
     productType === 'AGENT_API';
 
-  const supportsGateway =
+  const supportsHigress = productType === 'MCP_SERVER';
+
+  const supportsAIGateway =
     productType === 'REST_API' ||
     productType === 'MODEL_API' ||
     productType === 'MCP_SERVER' ||
     productType === 'AGENT_API';
+
+  // Higress 不支持时的提示文案
+  const higressDisabledReason = !supportsHigress
+    ? `Higress 网关暂不支持 ${PRODUCT_TYPE_LABELS[productType]} 批量导入`
+    : '';
+
+  // Nacos 不支持时的提示文案
+  const nacosDisabledReason =
+    productType === 'REST_API' || productType === 'MODEL_API'
+      ? `Nacos 不支持 ${PRODUCT_TYPE_LABELS[productType]} 导入`
+      : '';
 
   // 过滤服务列表
   const filteredServices = services.filter(service => {
@@ -113,7 +126,7 @@ export default function ImportProductsModal({
   const resetForm = () => {
     form.resetFields();
     // 根据产品类型设置默认数据源
-    const defaultSourceType = supportsGateway ? 'HIGRESS' : 'NACOS';
+    const defaultSourceType = supportsHigress ? 'HIGRESS' : supportsAIGateway ? 'AI_GATEWAY' : 'NACOS';
     setSourceType(defaultSourceType);
     setServices([]);
     setSelectedServiceKeys([]);
@@ -254,16 +267,7 @@ export default function ImportProductsModal({
         }
       } else {
         // Nacos 数据源
-        if (productType === 'REST_API') {
-          message.warning('REST API 仅支持从网关实例导入，不支持从 Nacos 导入');
-          setServices([]);
-        } else if (productType === 'MODEL_API') {
-          message.warning('Model API 仅支持从网关实例导入，不支持从 Nacos 导入');
-          setServices([]);
-        } else if (productType === 'AGENT_SKILL' || productType === 'WORKER') {
-          message.warning('Agent Skill 和 Worker 暂不支持通过此界面从 Nacos 导入');
-          setServices([]);
-        } else if (productType === 'MCP_SERVER') {
+        if (productType === 'MCP_SERVER') {
           res = await nacosApi.getNacosMcpServers(values.nacosId, {
             namespaceId: values.namespaceId,
             page: 0,
@@ -318,7 +322,7 @@ export default function ImportProductsModal({
       fetchGateways();
       fetchNacosInstances();
       // 根据产品类型设置默认数据源类型
-      const defaultSourceType = supportsGateway ? 'HIGRESS' : 'NACOS';
+      const defaultSourceType = supportsHigress ? 'HIGRESS' : supportsAIGateway ? 'AI_GATEWAY' : 'NACOS';
       setSourceType(defaultSourceType);
       form.setFieldValue('sourceType', defaultSourceType);
     }
@@ -472,15 +476,17 @@ export default function ImportProductsModal({
             placeholder="请选择数据源类型"
             onChange={handleSourceTypeChange}
           >
-            {supportsGateway && (
-              <>
-                <Select.Option value="HIGRESS">{SOURCE_TYPE_LABELS.HIGRESS}</Select.Option>
-                <Select.Option value="AI_GATEWAY">{SOURCE_TYPE_LABELS.AI_GATEWAY}</Select.Option>
-              </>
+            <Select.Option value="HIGRESS" disabled={!supportsHigress}>
+              {SOURCE_TYPE_LABELS.HIGRESS}
+              {higressDisabledReason && <span className="text-gray-400 text-xs ml-1">（{higressDisabledReason}）</span>}
+            </Select.Option>
+            {supportsAIGateway && (
+              <Select.Option value="AI_GATEWAY">{SOURCE_TYPE_LABELS.AI_GATEWAY}</Select.Option>
             )}
-            {supportsNacos && (
-              <Select.Option value="NACOS">{SOURCE_TYPE_LABELS.NACOS}</Select.Option>
-            )}
+            <Select.Option value="NACOS" disabled={!!nacosDisabledReason}>
+              {SOURCE_TYPE_LABELS.NACOS}
+              {nacosDisabledReason && <span className="text-gray-400 text-xs ml-1">（{nacosDisabledReason}）</span>}
+            </Select.Option>
           </Select>
         </Form.Item>
 

--- a/himarket-web/himarket-admin/src/pages/ProductTypePage.tsx
+++ b/himarket-web/himarket-admin/src/pages/ProductTypePage.tsx
@@ -40,6 +40,7 @@ const ProductTypePage: React.FC<ProductTypePageProps> = ({ productType }) => {
   const [importModalVisible, setImportModalVisible] = useState(false);
 
   const showNacosImport = productType === 'AGENT_SKILL' || productType === 'WORKER';
+  const showBatchImport = productType !== 'AGENT_SKILL' && productType !== 'WORKER';
   const isMcpServer = productType === 'MCP_SERVER';
   const [mcpImportOpen, setMcpImportOpen] = useState(false);
 
@@ -145,12 +146,14 @@ const ProductTypePage: React.FC<ProductTypePageProps> = ({ productType }) => {
               从 Nacos 导入
             </Button>
           )}
-          <Button
-            onClick={() => setImportModalVisible(true)}
-            icon={<ImportOutlined />}
-          >
-            批量导入
-          </Button>
+          {showBatchImport && (
+            <Button
+              onClick={() => setImportModalVisible(true)}
+              icon={<ImportOutlined />}
+            >
+              批量导入
+            </Button>
+          )}
           {!isMcpServer && (
             <Button
               onClick={() => tableRef.current?.handleCreate()}


### PR DESCRIPTION
## 📝 Description

- Fix HigressModelResult missing `modelApiId`/`modelApiName` fields, which caused the import dialog to show empty service names when importing from Higress
- Add backend validation in `validateImportParam`: Higress gateway only supports MCP_SERVER batch import; REST_API, AGENT_API, and MODEL_API are explicitly rejected with clear error messages
- Add backend validation: Nacos source does not support REST_API import
- Fix `HigressOperator.fetchAgentAPIs()` returning `null` instead of empty `PageResult`, which could cause NPE
- Frontend: show all source type options (Higress/AI Gateway/Nacos) but disable unsupported combinations with tooltip explaining why, instead of hiding them — this is more friendly for community users
- Frontend: hide "批量导入" button for AGENT_SKILL and WORKER product types, as they have their own dedicated Nacos import flow

### Background

The batch import feature was originally designed for MCP_SERVER and AGENT_API from Gateway/Nacos. However, it was inadvertently exposed for all product types including REST_API, MODEL_API, AGENT_SKILL, and WORKER. This caused several issues:

| Product Type | Higress | AI Gateway | Nacos |
|---|---|---|---|
| MCP_SERVER | ✅ Works | ✅ Works | ✅ Works |
| AGENT_API | ❌ Returns null → NPE | ✅ Works | ✅ Works |
| MODEL_API | ❌ Route name ≠ model ID | ✅ Works | ❌ Not supported |
| REST_API | ❌ Throws UnsupportedOperationException | ✅ Works | ❌ Not supported |
| AGENT_SKILL/WORKER | N/A (has dedicated import) | N/A | N/A |

## 🔗 Related Issues

Fix #272

## ✅ Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## 🧪 Testing

- [x] Manual testing completed
- Verified Higress + REST_API returns `INVALID_REQUEST` with clear message
- Verified Higress + MODEL_API returns `INVALID_REQUEST` with clear message
- Verified Higress + AGENT_API returns `INVALID_REQUEST` with clear message
- Verified Higress + MCP_SERVER still works correctly
- Verified frontend disables unsupported source types with tooltip

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend, `npm run lint:fix` for frontend)
- [x] Code is self-reviewed
- [x] No breaking changes
- [x] All CI checks pass