### PR TITLE
fix: mcp工具注册时required参数被错误移除导致LLM调用传参为空

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/manager/ChatBotManager.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/manager/ChatBotManager.java
@@ -294,12 +294,11 @@ public class ChatBotManager {
      */
     private void registerTool(Toolkit toolkit, McpClientWrapper client, McpSchema.Tool tool) {
         try {
-            java.util.Set<String> required =
-                    tool.inputSchema() != null && tool.inputSchema().required() != null
-                            ? new java.util.HashSet<>(tool.inputSchema().required())
-                            : java.util.Collections.emptySet();
+            // Note: The second parameter of convertMcpSchemaToParameters is presetKeys
+            // (parameters to exclude from schema because they have preset values).
+            // Pass null since we have no preset parameters here.
             Map<String, Object> parameters =
-                    McpTool.convertMcpSchemaToParameters(tool.inputSchema(), required);
+                    McpTool.convertMcpSchemaToParameters(tool.inputSchema(), null);
             McpTool mcpTool =
                     new McpTool(
                             tool.name(),


### PR DESCRIPTION
## 📝 Description

修复 MCP 工具注册时参数 schema 被错误裁剪的 bug。

`McpTool.convertMcpSchemaToParameters(schema, presetKeys)` 的第二个参数 `presetKeys` 用于指定需要从 schema 中移除的预设参数（这些参数已有预设值，不需要 LLM 填写）。

原代码错误地将 `inputSchema.required()` 作为 `presetKeys` 传入，导致所有标记为 required 的参数都被从 properties 和 required 列表中移除。LLM 看到的工具定义中缺少这些参数，调用时传参为空。

**根因：**

```java
// Before (bug): required 参数被当作 presetKeys 移除
Set<String> required = new HashSet<>(tool.inputSchema().required());
McpTool.convertMcpSchemaToParameters(tool.inputSchema(), required);

// After (fix): 没有预设参数，传 null
McpTool.convertMcpSchemaToParameters(tool.inputSchema(), null);
```

**为什么时有时无：** 只有 required 参数被移除，optional 参数不受影响。如果工具的所有参数都是 required（大多数 MCP 工具如此），则全部丢失；如果工具没有 required 参数，则不受影响。

## 🔗 Related Issues

- Fix #253

## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] Manual testing completed
- [x] All tests pass locally

验证方式：添加 MCP Server 后在 chat 中调用工具，确认 LLM 能正确传递 required 参数。

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend, `npm run lint:fix` for frontend)
- [x] Code is self-reviewed
- [x] Comments added for complex code
- [x] No breaking changes (or migration guide provided)

## 📚 Additional Notes

改动仅一处：`ChatBotManager.registerTool()` 方法中 `convertMcpSchemaToParameters` 的第二个参数从 `required` 改为 `null`。