### PR TITLE
fix: 修复 Skill 上传时 data_id 超长和 Jackson 反序列化超限问题

### DIFF
--- a/himarket-bootstrap/src/main/java/com/alibaba/himarket/config/JacksonConfig.java
+++ b/himarket-bootstrap/src/main/java/com/alibaba/himarket/config/JacksonConfig.java
@@ -47,9 +47,7 @@ public class JacksonConfig {
 
     static {
         StreamReadConstraints constraints =
-                StreamReadConstraints.builder()
-                        .maxStringLength(MAX_STRING_LENGTH)
-                        .build();
+                StreamReadConstraints.builder().maxStringLength(MAX_STRING_LENGTH).build();
         StreamReadConstraints.overrideDefaultStreamReadConstraints(constraints);
     }
 }

--- a/himarket-bootstrap/src/main/java/com/alibaba/himarket/config/JacksonConfig.java
+++ b/himarket-bootstrap/src/main/java/com/alibaba/himarket/config/JacksonConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.alibaba.himarket.config;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Global Jackson configuration.
+ *
+ * <p>Overrides the default {@link StreamReadConstraints} to allow deserializing large JSON strings.
+ * This is necessary because the Nacos SDK uses its own internal {@code ObjectMapper} (via {@code
+ * JacksonUtils}) which inherits the JVM-wide default constraints. Without this override, Skill
+ * resources larger than 20 MB will fail to deserialize with a {@code
+ * StreamConstraintsException}.
+ *
+ * <p>The limit is set to 50 MB (50,000,000 chars) instead of unlimited, which is sufficient for
+ * the maximum Skill ZIP size (10 MB) after decompression and base64 encoding expansion (~1.33x),
+ * while still providing a safety net against excessively large payloads.
+ *
+ * @see <a href="https://github.com/higress-group/himarket/issues/279">Issue #279</a>
+ */
+@Configuration
+public class JacksonConfig {
+
+    /**
+     * 50 MB in characters — sufficient for 10 MB ZIP decompressed content with base64 overhead.
+     */
+    private static final int MAX_STRING_LENGTH = 50_000_000;
+
+    static {
+        StreamReadConstraints constraints =
+                StreamReadConstraints.builder()
+                        .maxStringLength(MAX_STRING_LENGTH)
+                        .build();
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(constraints);
+    }
+}

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
@@ -798,8 +798,7 @@ public class SkillServiceImpl implements SkillService {
                 throw new BusinessException(
                         ErrorCode.INVALID_PARAMETER,
                         String.format(
-                                "资源文件路径过长，Nacos 编码后为 %d 字符（上限 %d）。"
-                                        + "请缩短文件名或减少目录层级: %s",
+                                "资源文件路径过长，Nacos 编码后为 %d 字符（上限 %d）。" + "请缩短文件名或减少目录层级: %s",
                                 encoded.length(), NACOS_DATA_ID_MAX_LENGTH, path));
             }
         }

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
@@ -10,6 +10,7 @@ import com.alibaba.himarket.core.exception.ErrorCode;
 import com.alibaba.himarket.core.security.ContextHolder;
 import com.alibaba.himarket.core.skill.FileTreeBuilder;
 import com.alibaba.himarket.core.skill.SkillMdBuilder;
+import com.alibaba.himarket.core.skill.SkillZipParser;
 import com.alibaba.himarket.core.utils.IdGenerator;
 import com.alibaba.himarket.dto.converter.OutputConverter;
 import com.alibaba.himarket.dto.result.cli.CliDownloadInfo;
@@ -26,6 +27,7 @@ import com.alibaba.himarket.support.enums.ProductStatus;
 import com.alibaba.himarket.support.enums.ProductType;
 import com.alibaba.himarket.support.product.ProductFeature;
 import com.alibaba.himarket.support.product.SkillConfig;
+import com.alibaba.nacos.api.ai.model.NacosAiConfigKeyCodec;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
 import com.alibaba.nacos.api.ai.model.skills.SkillMeta;
 import com.alibaba.nacos.api.ai.model.skills.SkillResource;
@@ -59,6 +61,15 @@ public class SkillServiceImpl implements SkillService {
 
     private static final long MAX_ZIP_SIZE = 10 * 1024 * 1024;
 
+    /**
+     * Nacos config_info.data_id 列的最大长度（varchar(256)）。
+     * 资源文件路径经过 {@link NacosAiConfigKeyCodec#encodeSegment} 编码后不能超过此值，
+     * 否则 Nacos 写入数据库时会抛出 DataIntegrityViolationException。
+     *
+     * @see <a href="https://github.com/higress-group/himarket/issues/278">Issue #278</a>
+     */
+    private static final int NACOS_DATA_ID_MAX_LENGTH = 256;
+
     private final NacosService nacosService;
 
     private final ProductRepository productRepository;
@@ -75,6 +86,12 @@ public class SkillServiceImpl implements SkillService {
         SkillRef ref = getSkillRef(productId, true);
 
         byte[] zipBytes = file.getBytes();
+
+        // Pre-validate: parse ZIP locally and check resource path lengths.
+        // Nacos hex-encodes paths containing invalid chars (e.g. "/"), which can
+        // double the length and exceed the config_info.data_id varchar(256) limit.
+        // See: https://github.com/higress-group/himarket/issues/278
+        validateResourcePathLengths(zipBytes);
 
         SkillConfig config = product.getFeature().getSkillConfig();
 
@@ -749,6 +766,43 @@ public class SkillServiceImpl implements SkillService {
             return type + "/" + name;
         }
         return name;
+    }
+
+    /**
+     * 校验 ZIP 中所有资源文件路径经过 Nacos 编码后是否会超过 data_id 列长度限制。
+     *
+     * <p>Nacos 使用 {@link NacosAiConfigKeyCodec#encodeSegment} 对资源路径进行编码：
+     * 当路径包含非法字符（如 {@code /}）时，整个字符串会被 hex 编码为 {@code enc.} + 十六进制，
+     * 长度约为原始长度的 2 倍 + 4。如果编码后超过 256 字符，写入 Nacos 数据库时会报
+     * {@code DataIntegrityViolationException: Data too long for column 'data_id'}。
+     *
+     * @param zipBytes ZIP 文件字节
+     * @throws BusinessException 如果任何资源路径编码后超过限制
+     * @see <a href="https://github.com/higress-group/himarket/issues/278">Issue #278</a>
+     */
+    private void validateResourcePathLengths(byte[] zipBytes) {
+        Skill skill;
+        try {
+            skill = SkillZipParser.parseSkillFromZip(zipBytes, "");
+        } catch (Exception e) {
+            // ZIP 解析失败由后续 Nacos 上传处理，这里不重复报错
+            return;
+        }
+        if (skill == null || skill.getResource() == null) {
+            return;
+        }
+        for (SkillResource resource : skill.getResource().values()) {
+            String path = buildResourcePath(resource);
+            String encoded = NacosAiConfigKeyCodec.encodeSegment(path);
+            if (encoded != null && encoded.length() > NACOS_DATA_ID_MAX_LENGTH) {
+                throw new BusinessException(
+                        ErrorCode.INVALID_PARAMETER,
+                        String.format(
+                                "资源文件路径过长，Nacos 编码后为 %d 字符（上限 %d）。"
+                                        + "请缩短文件名或减少目录层级: %s",
+                                encoded.length(), NACOS_DATA_ID_MAX_LENGTH, path));
+            }
+        }
     }
 
     private void writeZipEntry(ZipOutputStream zos, String path, byte[] data) throws IOException {


### PR DESCRIPTION
## 📝 Description

修复 Agent Skill 上传/下载流程中的两个 Bug：

- **Issue #278**：在 `SkillServiceImpl.uploadPackage()` 中增加前置校验，上传 ZIP 给 Nacos 前先本地解析资源文件路径，用 `NacosAiConfigKeyCodec.encodeSegment()` 模拟 Nacos 的编码逻辑，检查编码后长度是否超过 `config_info.data_id` 的 `varchar(256)` 限制。超过则返回清晰的 `INVALID_PARAMETER` 错误提示，避免请求打到 Nacos DB 层才报 `DataIntegrityViolationException`
- **Issue #279**：新增 `JacksonConfig` 全局配置，通过 `StreamReadConstraints.overrideDefaultStreamReadConstraints()` 将 `maxStringLength` 从默认 20M 放宽到 50M，使 Nacos SDK 内部的 `ObjectMapper` 能正常反序列化包含大体积资源（如 Figma JSON）的 Skill 数据

## 🔗 Related Issues

Fix #278
Fix #279

## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] Manual testing completed

手动验证步骤：
1. 构造一个资源文件路径超过 126 字符的 Skill ZIP 包上传，确认返回清晰的 `INVALID_PARAMETER` 错误（而非 `INTERNAL_ERROR`）
2. 构造一个路径正常的 Skill ZIP 包上传，确认上传成功不受影响

## 📋 Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend)
- [x] Code is self-reviewed
- [x] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

## 📚 Additional Notes

Issue #278 的根因在 Nacos Server 端：`NacosConfigAiResourceStorage.save()` 对含 `/` 的资源路径做全量 hex 编码（`enc.` + 十六进制），导致长度翻倍。当原始路径超过 126 个 ASCII 字符时，编码后超过 `varchar(256)` 限制。本 PR 在 HiMarket 端做防御性校验，根本修复需要 Nacos 上游调整 DB schema 或编码策略。
