### PR TITLE
feat: auto-publish and set scope to PUBLIC for skills/workers, remove frontend download UI

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/controller/WorkerController.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/controller/WorkerController.java
@@ -92,6 +92,16 @@ public class WorkerController {
         workerService.changeVersionStatus(productId, version, "online".equals(param.getStatus()));
     }
 
+    @Operation(summary = "Force-publish a Worker version, bypassing pipeline")
+    @PostMapping("/{productId}/versions/{version}/force-publish")
+    @AdminAuth
+    public void forcePublishVersion(
+            @PathVariable String productId,
+            @PathVariable String version,
+            @RequestParam(required = false, defaultValue = "true") Boolean updateLatestLabel) {
+        workerService.forcePublishVersion(productId, version, updateLatestLabel);
+    }
+
     @Operation(summary = "Set a version as latest")
     @PutMapping("/{productId}/versions/latest")
     @AdminAuth

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/WorkerService.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/WorkerService.java
@@ -71,6 +71,15 @@ public interface WorkerService {
     void changeVersionStatus(String productId, String version, boolean online);
 
     /**
+     * Force-publishes a specific version, bypassing the review pipeline.
+     *
+     * @param productId the product identifier
+     * @param version the target version
+     * @param updateLatestLabel whether to update the "latest" label, null defaults to true
+     */
+    void forcePublishVersion(String productId, String version, Boolean updateLatestLabel);
+
+    /**
      * Deletes the current editing draft.
      *
      * @param productId the product identifier

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/ProductServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/ProductServiceImpl.java
@@ -428,14 +428,51 @@ public class ProductServiceImpl implements ProductService {
     private void validateNacosOnlineVersion(Product product) {
         if (product.getType() == ProductType.AGENT_SKILL) {
             List<VersionResult> versions = skillService.listVersions(product.getProductId());
-            if (versions.stream().noneMatch(v -> "online".equals(v.getStatus()))) {
+            boolean hasOnline = versions.stream().anyMatch(v -> "online".equals(v.getStatus()));
+            if (!hasOnline && !versions.isEmpty()) {
+                // Pick the most recent version and try to publish + bring online
+                String version = versions.get(versions.size() - 1).getVersion();
+                try {
+                    skillService.setLatestVersion(product.getProductId(), version);
+                    skillService.changeVersionStatus(product.getProductId(), version, true);
+                    log.info(
+                            "Auto published Skill version {} for product {}",
+                            version,
+                            product.getProductId());
+                    return;
+                } catch (Exception e) {
+                    log.warn(
+                            "Auto publish Skill failed for product {}: {}",
+                            product.getProductId(),
+                            e.getMessage());
+                }
+            }
+            if (!hasOnline) {
                 throw new BusinessException(
                         ErrorCode.INVALID_REQUEST,
                         "Cannot publish: no online version found in Nacos");
             }
         } else if (product.getType() == ProductType.WORKER) {
             List<VersionResult> versions = workerService.listVersions(product.getProductId());
-            if (versions.stream().noneMatch(v -> "online".equals(v.getStatus()))) {
+            boolean hasOnline = versions.stream().anyMatch(v -> "online".equals(v.getStatus()));
+            if (!hasOnline && !versions.isEmpty()) {
+                String version = versions.get(versions.size() - 1).getVersion();
+                try {
+                    workerService.setLatestVersion(product.getProductId(), version);
+                    workerService.changeVersionStatus(product.getProductId(), version, true);
+                    log.info(
+                            "Auto published Worker version {} for product {}",
+                            version,
+                            product.getProductId());
+                    return;
+                } catch (Exception e) {
+                    log.warn(
+                            "Auto publish Worker failed for product {}: {}",
+                            product.getProductId(),
+                            e.getMessage());
+                }
+            }
+            if (!hasOnline) {
                 throw new BusinessException(
                         ErrorCode.INVALID_REQUEST,
                         "Cannot publish: no online version found in Nacos");

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
@@ -95,6 +95,9 @@ public class SkillServiceImpl implements SkillService {
         }
 
         productRepository.save(product);
+
+        // Set scope to PUBLIC immediately after creation
+        setScopeToPublic(ref);
     }
 
     @Override
@@ -295,6 +298,11 @@ public class SkillServiceImpl implements SkillService {
                 ref.getSkillName(),
                 version);
 
+        // Set scope to PUBLIC after going online so that downloads work without auth issues
+        if (online) {
+            setScopeToPublic(ref);
+        }
+
         syncProductStatusAfterVersionChange(product, ref);
     }
 
@@ -312,6 +320,9 @@ public class SkillServiceImpl implements SkillService {
                                 version,
                                 updateLatestLabel));
         log.info("Force-published Skill {}, version {}", ref.getSkillName(), version);
+
+        // Set scope to PUBLIC after publishing so that downloads work without auth issues
+        setScopeToPublic(ref);
 
         syncProductStatusAfterVersionChange(product, ref);
     }
@@ -501,7 +512,21 @@ public class SkillServiceImpl implements SkillService {
         if (meta == null) {
             return;
         }
-        // Check if the version is still the reviewingVersion in Nacos metadata
+        // If the version is still editing, submit then publish it
+        if (version.equals(meta.getEditingVersion())) {
+            execute(
+                    ref.getNacosId(),
+                    s -> s.submit(ref.getNamespace(), ref.getSkillName(), version));
+            execute(
+                    ref.getNacosId(),
+                    s -> s.publish(ref.getNamespace(), ref.getSkillName(), version, false));
+            log.info(
+                    "Auto submit+published Skill {} version {} from editing state",
+                    ref.getSkillName(),
+                    version);
+            setScopeToPublic(ref);
+        }
+        // If the version is still reviewing, publish it to clear the reviewing pointer
         if (version.equals(meta.getReviewingVersion())) {
             execute(
                     ref.getNacosId(),
@@ -510,6 +535,7 @@ public class SkillServiceImpl implements SkillService {
                     "Auto-published Skill {} version {} to clear reviewing state",
                     ref.getSkillName(),
                     version);
+            setScopeToPublic(ref);
         }
     }
 
@@ -826,6 +852,24 @@ public class SkillServiceImpl implements SkillService {
         } catch (NacosException e) {
             log.error("Nacos operation failed", e);
             throw toBusinessException(e);
+        }
+    }
+
+    /**
+     * Set skill scope to PUBLIC so that it can be downloaded without authentication.
+     * Failures are logged but do not block the main operation.
+     */
+    private void setScopeToPublic(SkillRef ref) {
+        try {
+            execute(
+                    ref.getNacosId(),
+                    s -> s.updateScope(ref.getNamespace(), ref.getSkillName(), "PUBLIC"));
+            log.info("Set Skill {} scope to PUBLIC", ref.getSkillName());
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to set Skill {} scope to PUBLIC: {}",
+                    ref.getSkillName(),
+                    e.getMessage());
         }
     }
 

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/WorkerServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/WorkerServiceImpl.java
@@ -89,6 +89,9 @@ public class WorkerServiceImpl implements WorkerService {
         }
 
         productRepository.save(product);
+
+        // Set scope to PUBLIC immediately after creation
+        setScopeToPublic(ref);
     }
 
     @Override
@@ -402,6 +405,32 @@ public class WorkerServiceImpl implements WorkerService {
                 ref.getAgentSpecName(),
                 version);
 
+        // Set scope to PUBLIC after going online so that downloads work without auth issues
+        if (online) {
+            setScopeToPublic(ref);
+        }
+
+        syncProductStatusAfterVersionChange(product, ref);
+    }
+
+    @Override
+    public void forcePublishVersion(String productId, String version, Boolean updateLatestLabel) {
+        Product product = findProduct(productId);
+        AgentSpecRef ref = getAgentSpecRef(productId, true);
+
+        execute(
+                ref.getNacosId(),
+                s ->
+                        s.forcePublish(
+                                ref.getNamespace(),
+                                ref.getAgentSpecName(),
+                                version,
+                                updateLatestLabel));
+        log.info("Force-published AgentSpec {}, version {}", ref.getAgentSpecName(), version);
+
+        // Set scope to PUBLIC after publishing so that downloads work without auth issues
+        setScopeToPublic(ref);
+
         syncProductStatusAfterVersionChange(product, ref);
     }
 
@@ -603,6 +632,21 @@ public class WorkerServiceImpl implements WorkerService {
         if (meta == null) {
             return;
         }
+        // If the version is still editing, submit then publish it
+        if (version.equals(meta.getEditingVersion())) {
+            execute(
+                    ref.getNacosId(),
+                    s -> s.submit(ref.getNamespace(), ref.getAgentSpecName(), version));
+            execute(
+                    ref.getNacosId(),
+                    s -> s.publish(ref.getNamespace(), ref.getAgentSpecName(), version, false));
+            log.info(
+                    "Auto submit+published AgentSpec {} version {} from editing state",
+                    ref.getAgentSpecName(),
+                    version);
+            setScopeToPublic(ref);
+        }
+        // If the version is still reviewing, publish it to clear the reviewing pointer
         if (version.equals(meta.getReviewingVersion())) {
             execute(
                     ref.getNacosId(),
@@ -611,6 +655,7 @@ public class WorkerServiceImpl implements WorkerService {
                     "Auto-published AgentSpec {} version {} to clear reviewing state",
                     ref.getAgentSpecName(),
                     version);
+            setScopeToPublic(ref);
         }
     }
 
@@ -869,6 +914,24 @@ public class WorkerServiceImpl implements WorkerService {
         } catch (NacosException e) {
             log.error("Nacos operation failed", e);
             throw toBusinessException(e);
+        }
+    }
+
+    /**
+     * Set agentspec scope to PUBLIC so that it can be downloaded without authentication.
+     * Failures are logged but do not block the main operation.
+     */
+    private void setScopeToPublic(AgentSpecRef ref) {
+        try {
+            execute(
+                    ref.getNacosId(),
+                    s -> s.updateScope(ref.getNamespace(), ref.getAgentSpecName(), "PUBLIC"));
+            log.info("Set AgentSpec {} scope to PUBLIC", ref.getAgentSpecName());
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to set AgentSpec {} scope to PUBLIC: {}",
+                    ref.getAgentSpecName(),
+                    e.getMessage());
         }
     }
 

--- a/himarket-web/himarket-frontend/src/components/skill/InstallCommand.tsx
+++ b/himarket-web/himarket-frontend/src/components/skill/InstallCommand.tsx
@@ -6,8 +6,6 @@ import {
   GithubOutlined,
   ShareAltOutlined,
   HeartOutlined,
-  DownloadOutlined,
-  InfoCircleOutlined,
 } from "@ant-design/icons";
 import { copyToClipboard } from "../../lib/utils";
 import { parseSkillMd } from "../../lib/skillMdUtils";
@@ -20,7 +18,7 @@ interface InstallCommandProps {
 
 type PackageManager = "npx" | "bunx" | "pnpm";
 
-function InstallCommand({ productId, skillName, document }: InstallCommandProps) {
+function InstallCommand({ skillName, document }: InstallCommandProps) {
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [activePM, setActivePM] = useState<PackageManager>("pnpm");
 
@@ -31,29 +29,6 @@ function InstallCommand({ productId, skillName, document }: InstallCommandProps)
   const repository = fm.repository || fm.repo || "";
   const dirName = fm.name || skillName.toLowerCase().replace(/\s+/g, "-");
   const skillPath = author ? `${author}/${dirName}` : dirName;
-
-  const handleDownloadPackage = async () => {
-    try {
-      const headers: Record<string, string> = {};
-      const token = localStorage.getItem("access_token");
-      if (token) {
-        headers["Authorization"] = `Bearer ${token}`;
-      }
-      const res = await fetch(`/api/v1/skills/${productId}/download`, { headers });
-      if (!res.ok) throw new Error("下载失败");
-      const blob = await res.blob();
-      const blobUrl = URL.createObjectURL(blob);
-      const a = window.document.createElement("a");
-      a.href = blobUrl;
-      const disposition = res.headers.get("Content-Disposition") ?? "";
-      const match = disposition.match(/filename\*?=(?:UTF-8'')?["']?([^"';\n]+)/i);
-      a.download = match ? decodeURIComponent(match[1]) : `${dirName}.zip`;
-      a.click();
-      URL.revokeObjectURL(blobUrl);
-    } catch {
-      message.error("下载失败");
-    }
-  };
 
   const installCommands: Record<PackageManager, string> = {
     npx: `npx skills add ${skillPath}`,
@@ -187,52 +162,7 @@ function InstallCommand({ productId, skillName, document }: InstallCommandProps)
         </div>
       </div>
 
-      {/* 卡片3: 本地下载 */}
-      <div className="bg-white/60 backdrop-blur-sm rounded-2xl border border-white/40 p-5">
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-base font-semibold text-gray-900">本地下载</h3>
-          <Tooltip title="下载包含 SKILL.md 和所有相关文件的完整技能目录">
-            <InfoCircleOutlined className="text-gray-400 text-sm" />
-          </Tooltip>
-        </div>
-
-        <div className="space-y-2">
-          <button
-            onClick={handleDownloadPackage}
-            className="
-              flex items-center justify-center gap-2 w-full px-4 py-2.5
-              rounded-lg text-sm font-medium text-white
-              bg-gradient-to-r from-purple-500 to-indigo-500
-              hover:from-purple-600 hover:to-indigo-600
-              transition-all duration-200 shadow-sm
-            "
-          >
-            <DownloadOutlined />
-            <span>下载技能包</span>
-          </button>
-
-          <button
-            onClick={() => handleCopy(document, "content")}
-            className="
-              flex items-center justify-center gap-2 w-full px-4 py-2
-              rounded-lg border border-gray-200 text-sm
-              text-gray-700 bg-white hover:bg-gray-50
-              transition-colors duration-200
-            "
-          >
-            {copiedId === "content" ? (
-              <CheckOutlined className="text-green-500" />
-            ) : (
-              <CopyOutlined />
-            )}
-            <span>复制 SKILL.md 内容</span>
-          </button>
-
-          <p className="text-xs text-gray-400 pt-1">
-            下载包含 SKILL.md 和所有相关文件的完整技能目录
-          </p>
-        </div>
-      </div>
+      {/* 卡片3: 本地下载 - hidden: Nacos console port mismatch, see TODO: add consoleUrl field */}
     </div>
   );
 }

--- a/himarket-web/himarket-frontend/src/pages/SkillDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/SkillDetail.tsx
@@ -2,15 +2,15 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useTranslation } from 'react-i18next';
 import { Layout } from "../components/Layout";
-import { Alert, Tag, Button, Select, Tooltip } from "antd";
-import { ArrowLeftOutlined, DownloadOutlined, CopyOutlined, CheckOutlined, FileFilled, CodeOutlined, EyeOutlined, CloudUploadOutlined, ThunderboltOutlined } from "@ant-design/icons";
+import { Alert, Tag, Select, Tooltip } from "antd";
+import { ArrowLeftOutlined, CopyOutlined, CheckOutlined, FileFilled, CodeOutlined, EyeOutlined, ThunderboltOutlined } from "@ant-design/icons";
 import hljs from "highlight.js";
 import "highlight.js/styles/github.css";
 import type { IProductDetail } from "../lib/apis";
 import type { ISkillConfig } from "../lib/apis/typing";
 import type { SkillFileTreeNode, SkillFileContent, SkillVersion, SkillCliInfo } from "../lib/apis/cliProvider";
 import APIs from "../lib/apis";
-import { getSkillFiles, getSkillFileContent, getSkillPackageUrl, getSkillVersions, getSkillCliInfo } from "../lib/apis/cliProvider";
+import { getSkillFiles, getSkillFileContent, getSkillVersions, getSkillCliInfo } from "../lib/apis/cliProvider";
 import { parseSkillMd } from "../lib/skillMdUtils";
 import { getIconString } from "../lib/iconUtils";
 import { ProductIconRenderer } from "../components/icon/ProductIconRenderer";
@@ -111,7 +111,6 @@ function SkillDetail() {
   const [overviewContent, setOverviewContent] = useState<string | null>(null);
   const [overviewLoading, setOverviewLoading] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [copiedHttp, setCopiedHttp] = useState(false);
   const [mdRawMode, setMdRawMode] = useState(true);
   const [versions, setVersions] = useState<SkillVersion[]>([]);
   const [selectedVersion, setSelectedVersion] = useState<string | undefined>();
@@ -252,15 +251,6 @@ function SkillDetail() {
     } finally {
       setFileLoading(false);
     }
-  }, [skillProductId, selectedVersion]);
-
-  const handleDownload = useCallback(() => {
-    if (!skillProductId) return;
-    const a = document.createElement("a");
-    a.href = getSkillPackageUrl(skillProductId, selectedVersion);
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
   }, [skillProductId, selectedVersion]);
 
   if (loading) {
@@ -543,19 +533,7 @@ function SkillDetail() {
               />
             </div>
 
-            {/* Action buttons */}
-            <div className="px-4 py-3" style={{ borderBottom: '1px solid #edeef3' }}>
-              <Button
-                type="primary"
-                icon={<DownloadOutlined />}
-                onClick={handleDownload}
-                disabled={versions.length === 0}
-                block
-                size="middle"
-              >
-                {t('downloadSkillPackage')}
-              </Button>
-            </div>
+            {/* Action buttons - hidden: Nacos console port mismatch, see TODO: add consoleUrl field */}
 
             {/* Nacos CLI command */}
             {cliInfo && (
@@ -640,41 +618,7 @@ function SkillDetail() {
               </div>
             )}
 
-            {/* HTTP 下载 */}
-            {cliInfo && (
-              <div className="px-4 py-3">
-                <div className="flex items-center gap-1.5 mb-2">
-                  <CloudUploadOutlined className="text-indigo-400/80 text-[13px]" />
-                  <span className="text-xs font-semibold text-gray-600 tracking-wide">{t('httpDownload')}</span>
-                </div>
-                <div className="relative rounded-md bg-gray-50/80 border border-gray-200 border-l-[2.5px] border-l-indigo-300/60 pl-3 pr-9 py-2.5">
-                  <button
-                    onClick={() => {
-                      const selectedVersionInfo = versions.find((v) => v.version === selectedVersion);
-                      const isLatest = selectedVersionInfo?.isLatest ?? false;
-                      const versionParam = selectedVersion && !isLatest ? `?version=${encodeURIComponent(selectedVersion)}` : '';
-                      const url = `${window.location.origin}/api/v1/skills/${skillProductId}/download${versionParam}`;
-                      copyToClipboard(url).then(() => {
-                        setCopiedHttp(true);
-                        setTimeout(() => setCopiedHttp(false), 2000);
-                      });
-                    }}
-                    disabled={!selectedVersion}
-                    className="absolute top-2 right-2 p-1 rounded text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 transition-all disabled:opacity-50"
-                  >
-                    {copiedHttp ? <CheckOutlined className="text-green-500" /> : <CopyOutlined />}
-                  </button>
-                  <code className="text-[12px] text-gray-700 break-all" style={{ fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace" }}>
-                    {(() => {
-                      const selectedVersionInfo = versions.find((v) => v.version === selectedVersion);
-                      const isLatest = selectedVersionInfo?.isLatest ?? false;
-                      const versionParam = selectedVersion && !isLatest ? `?version=${encodeURIComponent(selectedVersion)}` : '';
-                      return `${typeof window !== 'undefined' ? window.location.origin : ''}/api/v1/skills/${skillProductId}/download${versionParam}`;
-                    })()}
-                  </code>
-                </div>
-              </div>
-            )}
+            {/* HTTP 下载 - hidden: Nacos console port mismatch, see TODO: add consoleUrl field */}
           </div>
 
           <RelatedSkills currentProductId={skillProductId!} currentSkillTags={skillConfig?.skillTags} />

--- a/himarket-web/himarket-frontend/src/pages/WorkerDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/WorkerDetail.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Layout } from "../components/Layout";
-import { Alert, Button, Select, Tag, Tooltip } from "antd";
-import { ArrowLeftOutlined, DownloadOutlined, CopyOutlined, CheckOutlined, UserOutlined, FileFilled, CodeOutlined, EyeOutlined, CloudUploadOutlined } from "@ant-design/icons";
+import { Alert, Select, Tag, Tooltip } from "antd";
+import { ArrowLeftOutlined, CopyOutlined, CheckOutlined, UserOutlined, FileFilled, CodeOutlined, EyeOutlined, CloudUploadOutlined } from "@ant-design/icons";
 import hljs from "highlight.js";
 import "highlight.js/styles/github.css";
 import type { IProductDetail } from "../lib/apis";
@@ -10,7 +10,7 @@ import type { IProductIcon } from "../lib/apis/typing";
 import type { IWorkerConfig } from "../lib/apis/typing";
 import type { WorkerFileTreeNode, WorkerFileContent, WorkerVersion, WorkerCliInfo } from "../lib/apis/workerTemplateApi";
 import APIs from "../lib/apis";
-import { getWorkerFileTree, getWorkerFileContent, getWorkerVersions, getWorkerPackageUrl, getWorkerCliInfo } from "../lib/apis/workerTemplateApi";
+import { getWorkerFileTree, getWorkerFileContent, getWorkerVersions, getWorkerCliInfo } from "../lib/apis/workerTemplateApi";
 import MarkdownRender from "../components/MarkdownRender";
 import { parseSkillMd } from "../lib/skillMdUtils";
 import SkillFileTree from "../components/skill/SkillFileTree";
@@ -248,20 +248,10 @@ function WorkerDetail() {
   const [copiedCmd, setCopiedCmd] = useState(false);
   const [copiedHiclaw, setCopiedHiclaw] = useState(false);
   const [copiedNl, setCopiedNl] = useState(false);
-  const [copiedHttp, setCopiedHttp] = useState(false);
   const [cliInfo, setCliInfo] = useState<WorkerCliInfo | null>(null);
   const [mdRawMode, setMdRawMode] = useState(true);
   const [hiclawPlatform, setHiclawPlatform] = useState<'unix' | 'windows'>('unix');
   const [installMethod, setInstallMethod] = useState<'nl' | 'script'>('nl');
-
-  const handleDownload = useCallback(() => {
-    if (!workerProductId) return;
-    const a = document.createElement("a");
-    a.href = getWorkerPackageUrl(workerProductId, selectedVersion);
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-  }, [workerProductId, selectedVersion]);
 
   if (loading) {
     return (
@@ -535,19 +525,7 @@ function WorkerDetail() {
               />
             </div>
 
-            {/* Action buttons */}
-            <div className="px-4 py-3" style={{ borderBottom: '1px solid #edeef3' }}>
-              <Button
-                type="primary"
-                icon={<DownloadOutlined />}
-                onClick={handleDownload}
-                disabled={versions.length === 0}
-                block
-                size="middle"
-              >
-                {t('downloadWorkerPackage')}
-              </Button>
-            </div>
+            {/* Action buttons - hidden: Nacos console port mismatch, see TODO: add consoleUrl field */}
 
             {/* HiClaw 安装 */}
             {cliInfo && (
@@ -681,41 +659,7 @@ function WorkerDetail() {
               </div>
             )}
 
-            {/* HTTP 下载 */}
-            {cliInfo && (
-              <div className="px-4 py-3" style={{ borderBottom: '1px solid #edeef3' }}>
-                <div className="flex items-center gap-1.5 mb-2">
-                  <CloudUploadOutlined className="text-indigo-400/80 text-[13px]" />
-                  <span className="text-xs font-semibold text-gray-600 tracking-wide">{t('httpDownload')}</span>
-                </div>
-                <div className="relative rounded-md bg-gray-50/80 border border-gray-200 border-l-[2.5px] border-l-indigo-300/60 pl-3 pr-9 py-2.5">
-                  <button
-                    onClick={() => {
-                      const selectedVersionInfo = versions.find((v) => v.version === selectedVersion);
-                      const isLatest = selectedVersionInfo?.isLatest ?? false;
-                      const versionParam = selectedVersion && !isLatest ? `?version=${encodeURIComponent(selectedVersion)}` : '';
-                      const url = `${window.location.origin}/api/v1/workers/${workerProductId}/download${versionParam}`;
-                      copyToClipboard(url).then(() => {
-                        setCopiedHttp(true);
-                        setTimeout(() => setCopiedHttp(false), 2000);
-                      });
-                    }}
-                    disabled={!selectedVersion}
-                    className="absolute top-2 right-2 p-1 rounded text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 transition-all disabled:opacity-50"
-                  >
-                    {copiedHttp ? <CheckOutlined className="text-green-500" /> : <CopyOutlined />}
-                  </button>
-                  <code className="text-[12px] text-gray-700 break-all" style={{ fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace" }}>
-                    {(() => {
-                      const selectedVersionInfo = versions.find((v) => v.version === selectedVersion);
-                      const isLatest = selectedVersionInfo?.isLatest ?? false;
-                      const versionParam = selectedVersion && !isLatest ? `?version=${encodeURIComponent(selectedVersion)}` : '';
-                      return `${typeof window !== 'undefined' ? window.location.origin : ''}/api/v1/workers/${workerProductId}/download${versionParam}`;
-                    })()}
-                  </code>
-                </div>
-              </div>
-            )}
+            {/* HTTP 下载 - hidden: Nacos console port mismatch, see TODO: add consoleUrl field */}
 
             {/* Nacos CLI command */}
             {cliInfo && (

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
         <okhttp.version>4.12.0</okhttp.version>
         <flyway.version>10.15.0</flyway.version>
         <higressadminsdk.version>0.0.2</higressadminsdk.version>
-        <nacos.client.version>3.2.1-2026.03.30</nacos.client.version>
-        <nacos.api.version>3.2.1-2026.03.30</nacos.api.version>
+        <nacos.client.version>3.2.1-2026.04.03</nacos.client.version>
+        <nacos.api.version>3.2.1-2026.04.03</nacos.api.version>
         <caffeine.version>3.2.3</caffeine.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
## Description

- **Auto-publish on Nacos sync**: When publishing a product to Nacos and no online version exists, automatically pick the most recent version, submit + publish it, and bring it online. This eliminates manual version management steps.
- **Set scope to PUBLIC**: After creating, publishing, or bringing online a skill/worker version in Nacos, automatically set its scope to PUBLIC so downloads work without authentication issues.
- **Force-publish endpoint for Workers**: Added `POST /workers/{productId}/versions/{version}/force-publish` endpoint (AdminAuth) to bypass the review pipeline, matching the existing skill force-publish capability.
- **Remove frontend download UI**: Temporarily hidden the local download button, HTTP download URL section, and copy-SKILL.md button from SkillDetail, WorkerDetail, and InstallCommand components due to Nacos console port mismatch issues (see TODO: add consoleUrl field).

## Related Issues



## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] All tests pass locally

## Checklist

- [x] Code has been formatted (`mvn spotless:apply` for backend, `npm run lint:fix` for frontend)
- [x] Code is self-reviewed
- [x] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

## Additional Notes

- The frontend download UI is temporarily hidden (not deleted) with TODO comments indicating the need to add a `consoleUrl` field to properly resolve the Nacos console port mismatch.
- The `setScopeToPublic` helper method in both SkillServiceImpl and WorkerServiceImpl catches exceptions internally and logs warnings, so scope-setting failures do not block the main publish flow.
