### PR TITLE
fix(frontend): fix pagination off-by-one across multiple pages

### DIFF
--- a/himarket-web/himarket-admin/src/components/product-category/CategoryTable.tsx
+++ b/himarket-web/himarket-admin/src/components/product-category/CategoryTable.tsx
@@ -38,11 +38,11 @@ const CategoryTable = forwardRef<CategoryTableRef>((_, ref) => {
     (page = 1, size = 20, name = nameFilter) => {
       setLoading(true);
       const params: QueryProductCategoryParam = name.trim() ? { name: name.trim() } : {};
-      getProductCategoriesByPage(page - 1, size, params)
+      getProductCategoriesByPage(page, size, params)
         .then((res) => {
           setCategories(res.data.content || []);
           setPagination({
-            current: res.data.number + 1,
+            current: res.data.number,
             pageSize: res.data.size,
             total: res.data.totalElements,
           });

--- a/himarket-web/himarket-admin/src/components/subscription/SubscriptionListModal.tsx
+++ b/himarket-web/himarket-admin/src/components/subscription/SubscriptionListModal.tsx
@@ -44,7 +44,7 @@ export function SubscriptionListModal({
     setLoading(true);
     portalApi
       .getConsumerSubscriptions(consumerId, {
-        page: pagination.current - 1, // 后端从0开始
+        page: pagination.current,
         size: pagination.pageSize,
       })
       .then((res) => {

--- a/himarket-web/himarket-admin/src/pages/SandboxConsoles.tsx
+++ b/himarket-web/himarket-admin/src/pages/SandboxConsoles.tsx
@@ -56,7 +56,7 @@ export default function SandboxConsoles() {
     setLoading(true);
     try {
       const res: unknown = await sandboxApi.getSandboxes({
-        page: page - 1,
+        page: page,
         sandboxType: type,
         size,
       });

--- a/himarket-web/himarket-frontend/src/components/ProductHeader.tsx
+++ b/himarket-web/himarket-frontend/src/components/ProductHeader.tsx
@@ -187,7 +187,7 @@ export const ProductHeader = forwardRef<ProductHeaderHandle, ProductHeaderProps>
       try {
         const response = await getProductSubscriptions(productId, {
           consumerName: search.trim() || undefined,
-          page: page - 1, // 后端使用0基索引
+          page: page,
           size: pageSize,
         });
 

--- a/himarket-web/himarket-frontend/src/pages/McpSquare.tsx
+++ b/himarket-web/himarket-frontend/src/pages/McpSquare.tsx
@@ -131,7 +131,7 @@ function McpSquare() {
         const response = await APIs.getProducts({
           categoryIds,
           name: committedSearch || undefined,
-          page: currentPage - 1,
+          page: currentPage,
           size: PAGE_SIZE,
           type: 'MCP_SERVER',
         });


### PR DESCRIPTION
## 📝 Description

修复前端多个页面的分页 off-by-one 错误。

后端分页接口已统一使用 1-based 页码，但部分前端页面仍在请求时做 `page - 1` 转换，导致：
- 第 1 页实际请求的是第 0 页（与第 1 页数据相同，表现为翻页后数据不变）
- 后续页码始终偏移一页

涉及以下页面/组件：
- **CategoryTable**（产品分类列表）：请求和回显都做了多余的 ±1 转换
- **SubscriptionListModal**（订阅列表弹窗）：请求时多余的 -1
- **SandboxConsoles**（沙箱管理页）：请求时多余的 -1
- **ProductHeader**（产品详情-订阅列表）：请求时多余的 -1
- **McpSquare**（MCP 广场）：请求时多余的 -1

## 🔗 Related Issues



## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] All tests pass locally

## 📋 Checklist

- [ ] Code quality checks passed (run `./scripts/code-check.sh`)
- [x] Code is self-reviewed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

## 📊 Test Coverage

改动仅移除多余的 `page - 1` / `page + 1` 转换，无新增逻辑，不影响测试覆盖率。

## 📚 Additional Notes

改动量很小（5 个文件，6 行），每处都是去掉一个多余的 ±1 偏移。建议重点验证以下场景：
1. 各页面首次加载数据正确
2. 翻到第 2 页数据与第 1 页不同
3. 分页总数和当前页码显示正确
