### PR TITLE
fix(deploy): prevent shell injection in portal-developer init hooks

### DIFF
--- a/deploy/docker/hooks/post_ready.d/60-init-portal-developer.sh
+++ b/deploy/docker/hooks/post_ready.d/60-init-portal-developer.sh
@@ -43,6 +43,7 @@ declare -a SUBSCRIBED_PRODUCTS=()
 
 ########################################
 # 调用 API 通用函数
+# 参数: $1=接口名称 $2=HTTP方法 $3=HOST $4=路径 $5=请求体(可选) $6=Bearer令牌(可选)
 ########################################
 call_api() {
   local api_name="$1"
@@ -50,27 +51,39 @@ call_api() {
   local host="$3"
   local path="$4"
   local body="${5:-}"
-  local extra_args="${6:-}"
-  
+  local auth_token="${6:-}"
+
   local url="http://${host}${path}"
-  
+
   log "调用接口 [${api_name}]: ${method} ${url}"
-  
-  local curl_cmd="curl -sS -w '\nHTTP_CODE:%{http_code}' -X ${method} '${url}'"
-  curl_cmd="${curl_cmd} -H 'Content-Type: application/json'"
-  curl_cmd="${curl_cmd} -H 'Accept: application/json, text/plain, */*'"
-  
+
+  # Build curl arguments as an array to avoid shell injection via eval
+  local curl_args=(
+    -sS
+    -w $'\nHTTP_CODE:%{http_code}'
+    -X "$method"
+    "$url"
+    -H 'Content-Type: application/json'
+    -H 'Accept: application/json, text/plain, */*'
+  )
+
   if [[ -n "$body" ]]; then
-    curl_cmd="${curl_cmd} -d '${body}'"
+    curl_args+=(-d "$body")
   fi
-  
-  curl_cmd="${curl_cmd} ${extra_args} --connect-timeout 10 --max-time 30"
-  
-  local result=$(eval "$curl_cmd" 2>&1 || echo "HTTP_CODE:000")
-  
+
+  if [[ -n "$auth_token" ]]; then
+    curl_args+=(-H "Authorization: Bearer ${auth_token}")
+  fi
+
+  curl_args+=(--connect-timeout 10 --max-time 30)
+
+  # 执行 curl
+  local result
+  result=$(curl "${curl_args[@]}" 2>&1 || echo "HTTP_CODE:000")
+
   local http_code=""
   local response=""
-  
+
   if [[ "$result" =~ HTTP_CODE:([0-9]{3}) ]]; then
     http_code="${BASH_REMATCH[1]}"
     response=$(echo "$result" | sed '/HTTP_CODE:/d')
@@ -78,16 +91,16 @@ call_api() {
     http_code="000"
     response="$result"
   fi
-  
+
   log "接口 [${api_name}] 返回: HTTP ${http_code}"
-  
+
   if [[ -n "$response" && "$response" != "000" ]]; then
     log "响应内容: ${response}"
   fi
-  
+
   export API_RESPONSE="$response"
   export API_HTTP_CODE="$http_code"
-  
+
   if [[ "$http_code" =~ ^2[0-9]{2}$ ]]; then
     return 0
   elif [[ "$http_code" == "409" ]]; then
@@ -105,13 +118,13 @@ extract_json_field() {
   local json="$1"
   local field="$2"
   local value=""
-  
+
   value=$(echo "$json" | sed -n "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1)
-  
+
   if [[ -z "$value" ]]; then
     value=$(echo "$json" | grep -o "\"${field}\":\"[^\"]*\"" | head -1 | sed "s/\"${field}\":\"//" | sed 's/"$//')
   fi
-  
+
   echo "$value"
 }
 
@@ -120,11 +133,11 @@ extract_json_field() {
 ########################################
 step_1_register_developer() {
   local body="{\"username\":\"${FRONT_USERNAME}\",\"password\":\"${FRONT_PASSWORD}\"}"
-  
+
   local attempt=1
   while (( attempt <= MAX_RETRIES )); do
     log "执行步骤 1: 注册门户账号 (第 ${attempt}/${MAX_RETRIES} 次)..."
-    
+
     if call_api "注册门户账号" "POST" "${FRONTEND_HOST}" "/api/v1/developers" "$body"; then
       # 如果是 409，说明已存在
       if [[ "$API_HTTP_CODE" == "409" ]]; then
@@ -141,10 +154,10 @@ step_1_register_developer() {
         sleep 5
       fi
     fi
-    
+
     attempt=$((attempt+1))
   done
-  
+
   err "注册门户账号失败，已达最大重试次数"
   return 1
 }
@@ -154,28 +167,28 @@ step_1_register_developer() {
 ########################################
 step_2_admin_login() {
   local body="{\"username\":\"${ADMIN_USERNAME}\",\"password\":\"${ADMIN_PASSWORD}\"}"
-  
+
   local attempt=1
   while (( attempt <= MAX_RETRIES )); do
     log "执行步骤 2: 管理员登录 (第 ${attempt}/${MAX_RETRIES} 次)..."
-    
+
     if call_api "管理员登录" "POST" "${ADMIN_HOST}" "/api/v1/admins/login" "$body"; then
       # 提取 token
       ADMIN_TOKEN=$(extract_json_field "$API_RESPONSE" "access_token")
-      
+
       if [[ -z "$ADMIN_TOKEN" ]]; then
         ADMIN_TOKEN=$(extract_json_field "$API_RESPONSE" "token")
       fi
-      
+
       if [[ -z "$ADMIN_TOKEN" ]]; then
         ADMIN_TOKEN=$(extract_json_field "$API_RESPONSE" "accessToken")
       fi
-      
+
       if [[ -z "$ADMIN_TOKEN" ]]; then
         err "无法从登录响应中提取 token"
         return 1
       fi
-      
+
       log "管理员登录成功，获取到 Token: ${ADMIN_TOKEN:0:20}..."
       return 0
     else
@@ -185,10 +198,10 @@ step_2_admin_login() {
         sleep 5
       fi
     fi
-    
+
     attempt=$((attempt+1))
   done
-  
+
   err "管理员登录失败，已达最大重试次数"
   return 1
 }
@@ -197,17 +210,14 @@ step_2_admin_login() {
 # 步骤 3: 获取 Portal ID 和 Developer ID
 ########################################
 step_3_get_developer_info() {
-  # 先获取 Portal 列表获取 Portal ID
-  local extra_args="-H 'Authorization: Bearer ${ADMIN_TOKEN}'"
-  
   local attempt=1
   while (( attempt <= MAX_RETRIES )); do
     log "执行步骤 3.1: 获取 Portal ID (第 ${attempt}/${MAX_RETRIES} 次)..."
-    
-    if call_api "查询Portal列表" "GET" "${ADMIN_HOST}" "/api/v1/portals" "" "$extra_args"; then
+
+    if call_api "查询Portal列表" "GET" "${ADMIN_HOST}" "/api/v1/portals" "" "${ADMIN_TOKEN}"; then
       # 从列表中提取第一个 portalId
       PORTAL_ID=$(extract_json_field "$API_RESPONSE" "portalId")
-      
+
       if [[ -z "$PORTAL_ID" ]]; then
         err "无法从响应中提取 portalId"
         if (( attempt < MAX_RETRIES )); then
@@ -219,7 +229,7 @@ step_3_get_developer_info() {
           return 1
         fi
       fi
-      
+
       log "获取到 Portal ID: ${PORTAL_ID}"
       break
     else
@@ -229,38 +239,38 @@ step_3_get_developer_info() {
         sleep 5
       fi
     fi
-    
+
     attempt=$((attempt+1))
   done
-  
+
   if [[ -z "$PORTAL_ID" ]]; then
     err "无法获取 Portal ID"
     return 1
   fi
-  
+
   # 查询该 Portal 下的开发者列表
   attempt=1
   while (( attempt <= MAX_RETRIES )); do
     log "执行步骤 3.2: 获取 Developer ID (第 ${attempt}/${MAX_RETRIES} 次)..."
-    
-    if call_api "查询开发者列表" "GET" "${ADMIN_HOST}" "/api/v1/developers?portalId=${PORTAL_ID}&page=1&size=10" "" "$extra_args"; then
+
+    if call_api "查询开发者列表" "GET" "${ADMIN_HOST}" "/api/v1/developers?portalId=${PORTAL_ID}&page=1&size=10" "" "${ADMIN_TOKEN}"; then
       local temp_response="$API_RESPONSE"
-      
+
       # 查找包含目标用户名的开发者对象
       if echo "$temp_response" | grep -q "\"username\":\"${FRONT_USERNAME}\""; then
         # 提取该用户的 developerId
         DEVELOPER_ID=$(echo "$temp_response" | sed -n "s/.*\"developerId\":\"\([^\"]*\)\"[^}]*\"username\":\"${FRONT_USERNAME}\".*/\\1/p" | head -1)
-        
+
         if [[ -z "$DEVELOPER_ID" ]]; then
           DEVELOPER_ID=$(echo "$temp_response" | sed -n "s/.*\"username\":\"${FRONT_USERNAME}\"[^}]*\"developerId\":\"\([^\"]*\)\".*/\\1/p" | head -1)
         fi
-        
+
         if [[ -z "$DEVELOPER_ID" ]]; then
           local user_block=$(echo "$temp_response" | grep -o "{[^}]*\"username\":\"${FRONT_USERNAME}\"[^}]*}" | head -1)
           DEVELOPER_ID=$(extract_json_field "$user_block" "developerId")
         fi
       fi
-      
+
       if [[ -z "$DEVELOPER_ID" ]]; then
         err "未找到用户名为 ${FRONT_USERNAME} 的开发者"
         if (( attempt < MAX_RETRIES )); then
@@ -272,7 +282,7 @@ step_3_get_developer_info() {
           return 1
         fi
       fi
-      
+
       log "获取到 Developer ID: ${DEVELOPER_ID}"
       return 0
     else
@@ -282,10 +292,10 @@ step_3_get_developer_info() {
         sleep 5
       fi
     fi
-    
+
     attempt=$((attempt+1))
   done
-  
+
   err "获取 Developer ID 失败，已达最大重试次数"
   return 1
 }
@@ -298,15 +308,14 @@ step_4_approve_developer() {
     err "缺少 Developer ID 或 Portal ID，无法执行审批"
     return 1
   fi
-  
+
   local body="{\"portalId\":\"${PORTAL_ID}\",\"status\":\"APPROVED\"}"
-  local extra_args="-H 'Authorization: Bearer ${ADMIN_TOKEN}'"
-  
+
   local attempt=1
   while (( attempt <= MAX_RETRIES )); do
     log "执行步骤 4: 审批开发者 (第 ${attempt}/${MAX_RETRIES} 次)..."
-    
-    if call_api "审批开发者" "PATCH" "${ADMIN_HOST}" "/api/v1/developers/${DEVELOPER_ID}/status" "$body" "$extra_args"; then
+
+    if call_api "审批开发者" "PATCH" "${ADMIN_HOST}" "/api/v1/developers/${DEVELOPER_ID}/status" "$body" "${ADMIN_TOKEN}"; then
       log "开发者审批成功"
       return 0
     else
@@ -315,17 +324,17 @@ step_4_approve_developer() {
         log "开发者已处于审批通过状态（幂等）"
         return 0
       fi
-      
+
       err "审批开发者失败 (第 ${attempt} 次)"
       if (( attempt < MAX_RETRIES )); then
         log "等待 5 秒后重试..."
         sleep 5
       fi
     fi
-    
+
     attempt=$((attempt+1))
   done
-  
+
   err "审批开发者失败，已达最大重试次数"
   return 1
 }
@@ -335,36 +344,36 @@ step_4_approve_developer() {
 ########################################
 step_5_frontend_login() {
   local body="{\"username\":\"${FRONT_USERNAME}\",\"password\":\"${FRONT_PASSWORD}\"}"
-  
+
   local attempt=1
   while (( attempt <= MAX_RETRIES )); do
     log "执行步骤 5: 前台登录 (第 ${attempt}/${MAX_RETRIES} 次)..."
-    
+
     if call_api "前台登录" "POST" "${FRONTEND_HOST}" "/api/v1/developers/login" "$body"; then
       # 提取 token
       FRONTEND_TOKEN=$(extract_json_field "$API_RESPONSE" "access_token")
-      
+
       if [[ -z "$FRONTEND_TOKEN" ]]; then
         FRONTEND_TOKEN=$(extract_json_field "$API_RESPONSE" "token")
       fi
-      
+
       if [[ -z "$FRONTEND_TOKEN" ]]; then
         FRONTEND_TOKEN=$(extract_json_field "$API_RESPONSE" "accessToken")
       fi
-      
+
       if [[ -z "$FRONTEND_TOKEN" ]]; then
         err "无法从登录响应中提取 token"
         return 1
       fi
-      
+
       # 提取 consumerId（可能在登录响应中）
       CONSUMER_ID=$(extract_json_field "$API_RESPONSE" "consumerId")
-      
+
       log "前台登录成功，获取到 Token: ${FRONTEND_TOKEN:0:20}..."
       if [[ -n "$CONSUMER_ID" ]]; then
         log "获取到 Consumer ID: ${CONSUMER_ID}"
       fi
-      
+
       return 0
     else
       err "前台登录失败 (第 ${attempt} 次)"
@@ -373,10 +382,10 @@ step_5_frontend_login() {
         sleep 5
       fi
     fi
-    
+
     attempt=$((attempt+1))
   done
-  
+
   err "前台登录失败，已达最大重试次数"
   return 1
 }
@@ -389,21 +398,18 @@ step_6_get_subscription_info() {
   if [[ -n "$CONSUMER_ID" ]]; then
     log "已有 Consumer ID: ${CONSUMER_ID}，跳过查询"
   else
-    # 调用 consumers 列表接口获取 consumerId
-    local extra_args="-H 'Authorization: Bearer ${FRONTEND_TOKEN}'"
-    
     local attempt=1
     while (( attempt <= MAX_RETRIES )); do
       log "执行步骤 6.1: 获取 Consumer ID (第 ${attempt}/${MAX_RETRIES} 次)..."
-      
-      if call_api "查询Consumers列表" "GET" "${FRONTEND_HOST}" "/api/v1/consumers?page=1&size=100" "" "$extra_args"; then
+
+      if call_api "查询Consumers列表" "GET" "${FRONTEND_HOST}" "/api/v1/consumers?page=1&size=100" "" "${FRONTEND_TOKEN}"; then
         # 从列表中提取第一个 consumerId
         # API 返回格式: {"code":"SUCCESS","data":{"content":[{"consumerId":"xxx",...}],...}}
         CONSUMER_ID=$(echo "$API_RESPONSE" | jq -r '.data.content[0]?.consumerId // empty' 2>/dev/null || echo "")
         if [[ -z "$CONSUMER_ID" ]]; then
           CONSUMER_ID=$(extract_json_field "$API_RESPONSE" "consumerId")
         fi
-        
+
         if [[ -z "$CONSUMER_ID" ]]; then
           err "无法从响应中提取 consumerId"
           if (( attempt < MAX_RETRIES )); then
@@ -415,7 +421,7 @@ step_6_get_subscription_info() {
             return 1
           fi
         fi
-        
+
         log "获取到 Consumer ID: ${CONSUMER_ID}"
         break
       else
@@ -425,24 +431,22 @@ step_6_get_subscription_info() {
           sleep 5
         fi
       fi
-      
+
       attempt=$((attempt+1))
     done
-    
+
     if [[ -z "$CONSUMER_ID" ]]; then
       err "无法获取 Consumer ID"
       return 1
     fi
   fi
-  
+
   # 获取产品列表，查找所有可订阅的产品
-  local extra_args="-H 'Authorization: Bearer ${FRONTEND_TOKEN}'"
-  
   local attempt=1
   while (( attempt <= MAX_RETRIES )); do
     log "执行步骤 6.2: 获取可订阅产品列表 (第 ${attempt}/${MAX_RETRIES} 次)..."
-    
-    if call_api "查询产品列表" "GET" "${FRONTEND_HOST}" "/api/v1/products" "" "$extra_args"; then
+
+    if call_api "查询产品列表" "GET" "${FRONTEND_HOST}" "/api/v1/products" "" "${FRONTEND_TOKEN}"; then
       # 从列表中提取所有产品ID（使用 jq 处理）
       # API 返回格式: {"code":"SUCCESS","data":{"content":[{"productId":"xxx",...}],...}}
       local product_ids=$(echo "$API_RESPONSE" | jq -r '.data.content[]? | .productId // empty' 2>/dev/null || echo "")
@@ -451,18 +455,18 @@ step_6_get_subscription_info() {
         # 如果 jq 失败，尝试手动提取
         product_ids=$(echo "$API_RESPONSE" | grep -o '"productId":"[^"]*"' | sed 's/"productId":"//' | sed 's/"//')
       fi
-      
+
       if [[ -z "$product_ids" ]]; then
         log "警告: 未找到任何可订阅的产品"
         return 0
       fi
-      
+
       local product_count=$(echo "$product_ids" | wc -l | tr -d ' ')
       log "找到 ${product_count} 个可订阅产品"
-      
+
       # 将产品ID保存到全局变量（用于后续订阅）
       export PRODUCT_IDS="$product_ids"
-      
+
       return 0
     else
       err "查询产品列表失败 (第 ${attempt} 次)"
@@ -471,10 +475,10 @@ step_6_get_subscription_info() {
         sleep 5
       fi
     fi
-    
+
     attempt=$((attempt+1))
   done
-  
+
   err "获取产品列表失败，已达最大重试次数"
   return 1
 }
@@ -487,32 +491,31 @@ step_7_subscribe_products() {
     err "缺少 Consumer ID，无法执行订阅"
     return 1
   fi
-  
+
   if [[ -z "$PRODUCT_IDS" ]]; then
     log "没有可订阅的产品，跳过订阅步骤"
     return 0
   fi
-  
+
   local success_count=0
   local failed_count=0
   local skipped_count=0
   local failed_products=()
   local skipped_products=()
-  
+
   # 遍历所有产品ID并订阅
   while IFS= read -r product_id; do
     [[ -z "$product_id" ]] && continue
-    
+
     log "订阅产品: ${product_id}..."
-    
+
     local body="{\"productId\":\"${product_id}\"}"
-    local extra_args="-H 'Authorization: Bearer ${FRONTEND_TOKEN}'"
-    
+
     local attempt=1
     local subscribed=false
 
     while (( attempt <= MAX_RETRIES )); do
-      if call_api "订阅产品(${product_id})" "POST" "${FRONTEND_HOST}" "/api/v1/consumers/${CONSUMER_ID}/subscriptions" "$body" "$extra_args"; then
+      if call_api "订阅产品(${product_id})" "POST" "${FRONTEND_HOST}" "/api/v1/consumers/${CONSUMER_ID}/subscriptions" "$body" "${FRONTEND_TOKEN}"; then
         # 如果是 409，说明已订阅
         if [[ "$API_HTTP_CODE" == "409" ]]; then
           log "产品 ${product_id} 已订阅（幂等）"
@@ -556,7 +559,7 @@ step_7_subscribe_products() {
 
       attempt=$((attempt+1))
     done
-    
+
     if [[ "$subscribed" == "true" ]]; then
       success_count=$((success_count + 1))
       SUBSCRIBED_PRODUCTS+=("$product_id")
@@ -565,15 +568,15 @@ step_7_subscribe_products() {
       failed_count=$((failed_count + 1))
       failed_products+=("$product_id")
     fi
-    
+
   done <<< "$PRODUCT_IDS"
-  
+
   log "========================================"
   log "订阅结果汇总:"
   log "成功: ${success_count} 个"
   log "跳过（不支持订阅）: ${skipped_count} 个"
   log "失败: ${failed_count} 个"
-  
+
   if [[ ${#skipped_products[@]} -gt 0 ]]; then
     log ""
     log "跳过的产品列表（不支持订阅）:"
@@ -581,7 +584,7 @@ step_7_subscribe_products() {
       log "  ⊘ ${prod}"
     done
   fi
-  
+
   if [[ ${#failed_products[@]} -gt 0 ]]; then
     log ""
     log "失败的产品列表:"
@@ -589,9 +592,9 @@ step_7_subscribe_products() {
       log "  ✗ ${prod}"
     done
   fi
-  
+
   log "========================================"
-  
+
   # 只要有至少一个订阅成功，或者全部被跳过（不支持订阅），就认为整体成功
   if [[ $success_count -gt 0 ]] || [[ $failed_count -eq 0 ]]; then
     return 0
@@ -605,49 +608,49 @@ step_7_subscribe_products() {
 ########################################
 main() {
   log "开始初始化 Portal 开发者账号与订阅..."
-  
+
   # 步骤 1: 注册门户账号
   if ! step_1_register_developer; then
     err "步骤 1 失败，终止执行"
     exit 1
   fi
-  
+
   # 步骤 2: 管理员登录
   if ! step_2_admin_login; then
     err "步骤 2 失败，终止执行"
     exit 1
   fi
-  
+
   # 步骤 3: 获取 Portal ID 和 Developer ID
   if ! step_3_get_developer_info; then
     err "步骤 3 失败，终止执行"
     exit 1
   fi
-  
+
   # 步骤 4: 审批开发者
   if ! step_4_approve_developer; then
     err "步骤 4 失败，终止执行"
     exit 1
   fi
-  
+
   # 步骤 5: 前台登录
   if ! step_5_frontend_login; then
     err "步骤 5 失败，终止执行"
     exit 1
   fi
-  
+
   # 步骤 6: 获取 Consumer ID 和 Product ID
   if ! step_6_get_subscription_info; then
     err "步骤 6 失败，终止执行"
     exit 1
   fi
-  
+
   # 步骤 7: 订阅所有产品
   if ! step_7_subscribe_products; then
     err "步骤 7 失败，终止执行"
     exit 1
   fi
-  
+
   log "========================================"
   log "Portal 开发者账号与订阅初始化完成！"
   log "========================================"
@@ -657,7 +660,7 @@ main() {
   log "Developer ID: ${DEVELOPER_ID}"
   log "Consumer ID: ${CONSUMER_ID}"
   log "订阅产品数量: ${#SUBSCRIBED_PRODUCTS[@]}"
-  
+
   if [[ ${#SUBSCRIBED_PRODUCTS[@]} -gt 0 ]]; then
     log ""
     log "已订阅的产品列表:"
@@ -665,7 +668,7 @@ main() {
       log "  ✓ ${product_id}"
     done
   fi
-  
+
   log "前台访问地址: http://${FRONTEND_HOST}"
   log "========================================"
 }

--- a/deploy/helm/hooks/post_ready.d/60-init-portal-developer.sh
+++ b/deploy/helm/hooks/post_ready.d/60-init-portal-developer.sh
@@ -87,7 +87,7 @@ get_himarket_admin_host() {
 
 ########################################
 # 调用 API 通用函数
-# 参数: $1=接口名称 $2=HTTP方法 $3=HOST $4=路径 $5=请求体(可选) $6=额外curl参数(可选)
+# 参数: $1=接口名称 $2=HTTP方法 $3=HOST $4=路径 $5=请求体(可选) $6=Bearer令牌(可选)
 ########################################
 call_api() {
   local api_name="$1"
@@ -95,24 +95,35 @@ call_api() {
   local host="$3"
   local path="$4"
   local body="${5:-}"
-  local extra_args="${6:-}"
+  local auth_token="${6:-}"
 
   local url="http://${host}${path}"
 
   log "调用接口 [${api_name}]: ${method} ${url}"
 
-  local curl_cmd="curl -sS -w '\nHTTP_CODE:%{http_code}' -X ${method} '${url}'"
-  curl_cmd="${curl_cmd} -H 'Content-Type: application/json'"
-  curl_cmd="${curl_cmd} -H 'Accept: application/json, text/plain, */*'"
+  # Build curl arguments as an array to avoid shell injection via eval
+  local curl_args=(
+    -sS
+    -w $'\nHTTP_CODE:%{http_code}'
+    -X "$method"
+    "$url"
+    -H 'Content-Type: application/json'
+    -H 'Accept: application/json, text/plain, */*'
+  )
 
   if [[ -n "$body" ]]; then
-    curl_cmd="${curl_cmd} -d '${body}'"
+    curl_args+=(-d "$body")
   fi
 
-  curl_cmd="${curl_cmd} ${extra_args} --connect-timeout 10 --max-time 30"
+  if [[ -n "$auth_token" ]]; then
+    curl_args+=(-H "Authorization: Bearer ${auth_token}")
+  fi
+
+  curl_args+=(--connect-timeout 10 --max-time 30)
 
   # 执行 curl
-  local result=$(eval "$curl_cmd" 2>&1 || echo "HTTP_CODE:000")
+  local result
+  result=$(curl "${curl_args[@]}" 2>&1 || echo "HTTP_CODE:000")
 
   # 提取 HTTP 状态码和响应体
   local http_code=""
@@ -250,14 +261,11 @@ step_2_admin_login() {
 # 步骤 3: 获取 Portal ID 和 Developer ID
 ########################################
 step_3_get_developer_info() {
-  # 先获取 Portal 列表获取 Portal ID
-  local extra_args="-H 'Authorization: Bearer ${ADMIN_TOKEN}'"
-
   local attempt=1
   while (( attempt <= MAX_RETRIES )); do
     log "执行步骤 3.1: 获取 Portal ID (第 ${attempt}/${MAX_RETRIES} 次)..."
 
-    if call_api "查询Portal列表" "GET" "${ADMIN_HOST}" "/api/v1/portals" "" "$extra_args"; then
+    if call_api "查询Portal列表" "GET" "${ADMIN_HOST}" "/api/v1/portals" "" "${ADMIN_TOKEN}"; then
       # 从列表中提取第一个 portalId（或根据名称匹配）
       PORTAL_ID=$(extract_json_field "$API_RESPONSE" "portalId")
 
@@ -296,7 +304,7 @@ step_3_get_developer_info() {
   while (( attempt <= MAX_RETRIES )); do
     log "执行步骤 3.2: 获取 Developer ID (第 ${attempt}/${MAX_RETRIES} 次)..."
 
-    if call_api "查询开发者列表" "GET" "${ADMIN_HOST}" "/api/v1/developers?portalId=${PORTAL_ID}&page=1&size=10" "" "$extra_args"; then
+    if call_api "查询开发者列表" "GET" "${ADMIN_HOST}" "/api/v1/developers?portalId=${PORTAL_ID}&page=1&size=10" "" "${ADMIN_TOKEN}"; then
       # 从列表中查找 username 匹配的开发者
       # 使用复杂模式匹配提取 developerId
       local temp_response="$API_RESPONSE"
@@ -357,13 +365,12 @@ step_4_approve_developer() {
   fi
 
   local body="{\"portalId\":\"${PORTAL_ID}\",\"status\":\"APPROVED\"}"
-  local extra_args="-H 'Authorization: Bearer ${ADMIN_TOKEN}'"
 
   local attempt=1
   while (( attempt <= MAX_RETRIES )); do
     log "执行步骤 4: 审批开发者 (第 ${attempt}/${MAX_RETRIES} 次)..."
 
-    if call_api "审批开发者" "PATCH" "${ADMIN_HOST}" "/api/v1/developers/${DEVELOPER_ID}/status" "$body" "$extra_args"; then
+    if call_api "审批开发者" "PATCH" "${ADMIN_HOST}" "/api/v1/developers/${DEVELOPER_ID}/status" "$body" "${ADMIN_TOKEN}"; then
       log "开发者审批成功"
       return 0
     else
@@ -446,14 +453,11 @@ step_6_get_subscription_info() {
   if [[ -n "$CONSUMER_ID" ]]; then
     log "已有 Consumer ID: ${CONSUMER_ID}，跳过查询"
   else
-    # 调用 consumers 列表接口获取 consumerId
-    local extra_args="-H 'Authorization: Bearer ${FRONTEND_TOKEN}'"
-
     local attempt=1
     while (( attempt <= MAX_RETRIES )); do
       log "执行步骤 6.1: 获取 Consumer ID (第 ${attempt}/${MAX_RETRIES} 次)..."
 
-      if call_api "查询Consumers列表" "GET" "${FRONTEND_HOST}" "/api/v1/consumers?page=1&size=100" "" "$extra_args"; then
+      if call_api "查询Consumers列表" "GET" "${FRONTEND_HOST}" "/api/v1/consumers?page=1&size=100" "" "${FRONTEND_TOKEN}"; then
         # 从列表中提取第一个 consumerId
         # API 返回格式: {"code":"SUCCESS","data":{"content":[{"consumerId":"xxx",...}],...}}
         CONSUMER_ID=$(echo "$API_RESPONSE" | jq -r '.data.content[0]?.consumerId // empty' 2>/dev/null || echo "")
@@ -493,13 +497,11 @@ step_6_get_subscription_info() {
   fi
 
   # 获取产品列表，查找所有可订阅的产品
-  local extra_args="-H 'Authorization: Bearer ${FRONTEND_TOKEN}'"
-
   local attempt=1
   while (( attempt <= MAX_RETRIES )); do
     log "执行步骤 6.2: 获取可订阅产品列表 (第 ${attempt}/${MAX_RETRIES} 次)..."
 
-    if call_api "查询产品列表" "GET" "${FRONTEND_HOST}" "/api/v1/products" "" "$extra_args"; then
+    if call_api "查询产品列表" "GET" "${FRONTEND_HOST}" "/api/v1/products" "" "${FRONTEND_TOKEN}"; then
       # 从列表中提取所有产品ID（使用 jq 处理）
       # API 返回格式: {"code":"SUCCESS","data":{"content":[{"productId":"xxx",...}],...}}
       local product_ids=$(echo "$API_RESPONSE" | jq -r '.data.content[]? | .productId // empty' 2>/dev/null || echo "")
@@ -563,13 +565,12 @@ step_7_subscribe_products() {
     log "订阅产品: ${product_id}..."
 
     local body="{\"productId\":\"${product_id}\"}"
-    local extra_args="-H 'Authorization: Bearer ${FRONTEND_TOKEN}'"
 
     local attempt=1
     local subscribed=false
 
     while (( attempt <= MAX_RETRIES )); do
-      if call_api "订阅产品(${product_id})" "POST" "${FRONTEND_HOST}" "/api/v1/consumers/${CONSUMER_ID}/subscriptions" "$body" "$extra_args"; then
+      if call_api "订阅产品(${product_id})" "POST" "${FRONTEND_HOST}" "/api/v1/consumers/${CONSUMER_ID}/subscriptions" "$body" "${FRONTEND_TOKEN}"; then
         # 如果是 409，说明已订阅
         if [[ "$API_HTTP_CODE" == "409" ]]; then
           log "产品 ${product_id} 已订阅（幂等）"


### PR DESCRIPTION
## Summary

The `call_api()` helper used by the portal-developer initialization hooks (Docker and Helm deploys) builds a `curl` command line via string concatenation and executes it through `eval`. One of the interpolated values is the admin Bearer token returned by `/api/v1/admins/login`, parsed out of the JSON response with a regex and inserted into the command without escaping. Other interpolated values include the request body and host. This is a classic CWE-78 (OS Command Injection) pattern: any single-quote in a token, password, or response field breaks out of the quoting and executes arbitrary shell on the host running `install.sh` / `deploy.sh`.

Affected files:
- `deploy/docker/hooks/post_ready.d/60-init-portal-developer.sh`
- `deploy/helm/hooks/post_ready.d/60-init-portal-developer.sh`

The vulnerable construction looked like:

```bash
local curl_cmd="curl -sS -w '\nHTTP_CODE:%{http_code}' -X ${method} '${url}'"
curl_cmd="${curl_cmd} -d '${body}'"
curl_cmd="${curl_cmd} ${extra_args} --connect-timeout 10 --max-time 30"
local result=$(eval "$curl_cmd" 2>&1 || echo "HTTP_CODE:000")
```

`extra_args` was passed in as a literal string like `-H 'Authorization: Bearer ${ADMIN_TOKEN}'`, so the token value ended up parsed by the shell.

## Fix

Replace the string-concatenated `eval` with a bash array passed to `curl` directly, so each element is one literal argv entry and the shell never re-parses interpolated values:

```bash
local curl_args=(
  -sS
  -w $'\nHTTP_CODE:%{http_code}'
  -X "$method"
  "$url"
  -H 'Content-Type: application/json'
  -H 'Accept: application/json, text/plain, */*'
)
[[ -n "$body" ]]       && curl_args+=(-d "$body")
[[ -n "$auth_token" ]] && curl_args+=(-H "Authorization: Bearer ${auth_token}")
curl_args+=(--connect-timeout 10 --max-time 30)

result=$(curl "${curl_args[@]}" 2>&1 || echo "HTTP_CODE:000")
```

The 6th parameter changes from a free-form `extra_args` string to a typed `auth_token`, which makes misuse harder. All call sites in both scripts are updated to pass the raw token instead of a `-H 'Authorization: …'` fragment.

## Testing

I built a small standalone harness that mirrors the original `eval`-based `call_api()` and the array-based replacement, then drove both with a malicious admin token containing shell metacharacters (`'; touch /tmp/pwn; echo '`). With the original code the side-effect file was created; with the array version the token was passed verbatim to `curl` as a header value and no command executed. I also exercised normal payloads (typical JWTs, JSON bodies with quotes, URLs with query strings) and confirmed the request shape sent to a local mock HTTP server is unchanged. `shellcheck` is clean on both modified scripts.

## Security notes and exploitability

The preconditions are real but narrow:

- The `ADMIN_TOKEN` the script substitutes into the command is whatever the admin backend returns in `access_token`. A compromised or malicious `himarket-admin` container image could return a crafted token containing shell metacharacters, which would then execute on the host running `install.sh` (outside the container, as the operator's user). This is the most realistic path — it converts a container-image compromise into host code execution during initialization.
- Operator-supplied `FRONT_PASSWORD` / `ADMIN_PASSWORD` containing shell metacharacters (e.g. via a `~/himarket-install-docker.env` file in non-interactive mode) would also trigger the same injection.
- The hook talks to `localhost`, so plain network MITM is not a realistic vector.

The fix removes the parsing surface entirely rather than trying to sanitize the inputs.

### Adversarial review

Before submitting I tried to disprove this. The token comes from an HTTP response body parsed by a regex with no escaping; the response is constructed by another component the operator controls, but a tampered or malicious upstream image is exactly the supply-chain scenario that container-based deployments need to defend against, and the install hook runs on the host (not inside a container) as the user who invoked `install.sh`. There is no existing sanitization layer between `extract_json_field` and `eval`. Standard bash quoting around `${ADMIN_TOKEN}` does not help because the value is interpolated into a string that is later re-parsed by `eval`. So the issue is genuinely exploitable under the stated preconditions, and the array-based fix is the correct minimal remediation.

## Diff scope

Only the two `60-init-portal-developer.sh` hooks are modified; behavior on the success path is unchanged.