### PR TITLE
fix: map oidc token response fields with jackson

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/idp/IdpTokenResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/idp/IdpTokenResult.java
@@ -19,7 +19,7 @@
 
 package com.alibaba.himarket.dto.result.idp;
 
-import cn.hutool.core.annotation.Alias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
@@ -28,31 +28,31 @@ public class IdpTokenResult {
     /**
      * Access token
      */
-    @Alias("access_token")
+    @JsonProperty("access_token")
     private String accessToken;
 
     /**
      * ID token
      */
-    @Alias("id_token")
+    @JsonProperty("id_token")
     private String idToken;
 
     /**
      * Refresh token
      */
-    @Alias("refresh_token")
+    @JsonProperty("refresh_token")
     private String refreshToken;
 
     /**
      * Token type
      */
-    @Alias("token_type")
+    @JsonProperty("token_type")
     private String tokenType;
 
     /**
      * Expiration time in seconds
      */
-    @Alias("expires_in")
+    @JsonProperty("expires_in")
     private Integer expiresIn;
 
     /**


### PR DESCRIPTION
  ## 📝 Description

  - Fix OIDC token response deserialization after token responses are parsed through Jackson JsonUtil.
  - Replace Hutool @Alias annotations with Jackson @JsonProperty on IdpTokenResult OAuth/OIDC fields.
  - Ensure snake_case fields such as access_token and id_token map correctly to accessToken and idToken.

  ## ✅ Type of Change

  - [x] Bug fix (non-breaking change)
  - [ ] New feature (non-breaking change)
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement

  ## 🧪 Testing

  - [x] Built backend jar with Maven in Docker using JDK 17
  - [x] Built Docker image himarket-server:latest
  - [x] Pushed image to ekb-repo.tencentcloudcr.com/library/himarket-server:latest
  - [x] Ran git diff --check

  ## 📋 Checklist

  - [x] Code is self-reviewed
  - [x] No breaking changes
  - [x] Sensitive credentials are not included in code