### PR TITLE
fix: map oidc token response fields with jackson

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/idp/IdpTokenResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/idp/IdpTokenResult.java
@@ -19,7 +19,7 @@
 
 package com.alibaba.himarket.dto.result.idp;
 
-import cn.hutool.core.annotation.Alias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
@@ -28,31 +28,31 @@ public class IdpTokenResult {
     /**
      * Access token
      */
-    @Alias("access_token")
+    @JsonProperty("access_token")
     private String accessToken;
 
     /**
      * ID token
      */
-    @Alias("id_token")
+    @JsonProperty("id_token")
     private String idToken;
 
     /**
      * Refresh token
      */
-    @Alias("refresh_token")
+    @JsonProperty("refresh_token")
     private String refreshToken;
 
     /**
      * Token type
      */
-    @Alias("token_type")
+    @JsonProperty("token_type")
     private String tokenType;
 
     /**
      * Expiration time in seconds
      */
-    @Alias("expires_in")
+    @JsonProperty("expires_in")
     private Integer expiresIn;
 
     /**


### PR DESCRIPTION
## 📝 Description

- Replace Hutool `Alias` annotations with Jackson `JsonProperty` on `IdpTokenResult`.
- Ensure OIDC token response fields such as `access_token`, `id_token`, `refresh_token`, `token_type`, and `expires_in` map correctly when parsed through `JsonUtil`.
- This maintainer PR carries the same fix as #299, keeps the original contributor as co-author, and adds a maintainer DCO sign-off.

## ✅ Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## 🧪 Testing

- [x] Ran `git diff --check`
- [x] Ran `./mvnw -pl himarket-server -am -DskipTests compile`

## 📋 Checklist

- [x] Code is self-reviewed
- [x] No breaking changes
- [x] Sensitive credentials are not included in code

Supersedes #299.