### PR TITLE
fix: include nacos port in cli commands

### DIFF
--- a/himarket-web/himarket-frontend/src/lib/apis/cliProvider.ts
+++ b/himarket-web/himarket-frontend/src/lib/apis/cliProvider.ts
@@ -189,6 +189,7 @@ export function getSkillFileContent(productId: string, filePath: string, version
  */
 export interface SkillCliInfo {
   nacosHost: string;
+  nacosPort?: number;
   resourceName: string;
   resourceType: string;
 }

--- a/himarket-web/himarket-frontend/src/lib/nacosCliCommand.ts
+++ b/himarket-web/himarket-frontend/src/lib/nacosCliCommand.ts
@@ -1,0 +1,28 @@
+const DEFAULT_NACOS_HOST = 'market.hiclaw.io';
+
+export interface NacosCliServerInfo {
+  nacosHost: string;
+  nacosPort?: number;
+}
+
+export interface NacosCliCommandParams {
+  command: 'agentspec-get' | 'skill-get';
+  outputDir?: string;
+  resourceName: string;
+  server: NacosCliServerInfo;
+  version?: string;
+}
+
+function quoteIfNeeded(value: string): string {
+  return value.includes(' ') ? `"${value}"` : value;
+}
+
+export function buildNacosCliCommand(params: NacosCliCommandParams): string {
+  const isDefaultHost = params.server.nacosHost === DEFAULT_NACOS_HOST;
+  const hostArg = isDefaultHost ? '' : ` --host ${params.server.nacosHost}`;
+  const portArg = params.server.nacosPort ? ` --port ${params.server.nacosPort}` : '';
+  const outputArg = params.outputDir ? ` -o ${quoteIfNeeded(params.outputDir)}` : '';
+  const versionArg = params.version ? ` --version ${params.version}` : '';
+
+  return `npx @nacos-group/cli${hostArg}${portArg} ${params.command} ${quoteIfNeeded(params.resourceName)}${outputArg}${versionArg}`;
+}

--- a/himarket-web/himarket-frontend/src/lib/utils/nacosCliCommand.test.ts
+++ b/himarket-web/himarket-frontend/src/lib/utils/nacosCliCommand.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildNacosCliCommand } from '../nacosCliCommand';
+
+describe('buildNacosCliCommand', () => {
+  it('includes host and port for skill download commands', () => {
+    const command = buildNacosCliCommand({
+      command: 'skill-get',
+      outputDir: './my skills',
+      resourceName: 'demo skill',
+      server: {
+        nacosHost: 'nacos.himarket.hosecloud.com',
+        nacosPort: 80,
+      },
+      version: '1.0.0',
+    });
+
+    expect(command).toBe(
+      'npx @nacos-group/cli --host nacos.himarket.hosecloud.com --port 80 skill-get "demo skill" -o "./my skills" --version 1.0.0',
+    );
+  });
+
+  it('keeps port when the host is the default nacos host', () => {
+    const command = buildNacosCliCommand({
+      command: 'agentspec-get',
+      resourceName: 'agent-demo',
+      server: {
+        nacosHost: 'market.hiclaw.io',
+        nacosPort: 8848,
+      },
+    });
+
+    expect(command).toBe('npx @nacos-group/cli --port 8848 agentspec-get agent-demo');
+  });
+});

--- a/himarket-web/himarket-frontend/src/pages/SkillDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/SkillDetail.tsx
@@ -31,6 +31,7 @@ import {
   getSkillCliInfo,
 } from '../lib/apis/cliProvider';
 import { getIconString } from '../lib/iconUtils';
+import { buildNacosCliCommand } from '../lib/nacosCliCommand';
 import { parseSkillMd } from '../lib/skillMdUtils';
 import { copyToClipboard } from '../lib/utils';
 
@@ -780,18 +781,17 @@ function SkillDetail() {
                     <button
                       className="absolute top-2 right-2 p-1 rounded text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 transition-all"
                       onClick={() => {
-                        const quotedName = cliInfo.resourceName.includes(' ')
-                          ? `"${cliInfo.resourceName}"`
-                          : cliInfo.resourceName;
-                        const quotedDir = outputDir.includes(' ') ? `"${outputDir}"` : outputDir;
-                        const isDefaultHost = cliInfo.nacosHost === 'market.hiclaw.io';
-                        const hostArg = isDefaultHost ? '' : ` --host ${cliInfo.nacosHost}`;
                         const selectedVersionInfo = versions.find(
                           (v) => v.version === selectedVersion,
                         );
                         const isLatest = selectedVersionInfo?.isLatest ?? false;
-                        const versionArg = isLatest ? '' : ` --version ${selectedVersion}`;
-                        const cmd = `npx @nacos-group/cli${hostArg} skill-get ${quotedName} -o ${quotedDir}${versionArg}`;
+                        const cmd = buildNacosCliCommand({
+                          command: 'skill-get',
+                          outputDir,
+                          resourceName: cliInfo.resourceName,
+                          server: cliInfo,
+                          version: isLatest ? undefined : selectedVersion,
+                        });
                         copyToClipboard(cmd).then(() => {
                           setCopied(true);
                           setTimeout(() => setCopied(false), 2000);
@@ -805,14 +805,17 @@ function SkillDetail() {
                       style={{ fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace" }}
                     >
                       {(() => {
-                        const isDefaultHost = cliInfo.nacosHost === 'market.hiclaw.io';
-                        const hostArg = isDefaultHost ? '' : ` --host ${cliInfo.nacosHost}`;
                         const selectedVersionInfo = versions.find(
                           (v) => v.version === selectedVersion,
                         );
                         const isLatest = selectedVersionInfo?.isLatest ?? false;
-                        const versionArg = isLatest ? '' : ` --version ${selectedVersion}`;
-                        return `npx @nacos-group/cli${hostArg} skill-get ${cliInfo.resourceName.includes(' ') ? `"${cliInfo.resourceName}"` : cliInfo.resourceName} -o ${outputDir.includes(' ') ? `"${outputDir}"` : outputDir}${versionArg}`;
+                        return buildNacosCliCommand({
+                          command: 'skill-get',
+                          outputDir,
+                          resourceName: cliInfo.resourceName,
+                          server: cliInfo,
+                          version: isLatest ? undefined : selectedVersion,
+                        });
                       })()}
                     </code>
                   </div>

--- a/himarket-web/himarket-frontend/src/pages/WorkerDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/WorkerDetail.tsx
@@ -28,6 +28,7 @@ import {
   getWorkerPackageUrl,
   getWorkerCliInfo,
 } from '../lib/apis/workerTemplateApi';
+import { buildNacosCliCommand } from '../lib/nacosCliCommand';
 import { parseSkillMd } from '../lib/skillMdUtils';
 import { copyToClipboard } from '../lib/utils';
 
@@ -910,17 +911,16 @@ function WorkerDetail() {
                     <button
                       className="absolute top-2 right-2 p-1 rounded text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 transition-all"
                       onClick={() => {
-                        const quotedName = cliInfo.resourceName.includes(' ')
-                          ? `"${cliInfo.resourceName}"`
-                          : cliInfo.resourceName;
-                        const isDefaultHost = cliInfo.nacosHost === 'market.hiclaw.io';
-                        const hostArg = isDefaultHost ? '' : ` --host ${cliInfo.nacosHost}`;
                         const selectedVersionInfo = versions.find(
                           (v) => v.version === selectedVersion,
                         );
                         const isLatest = selectedVersionInfo?.isLatest ?? false;
-                        const versionArg = isLatest ? '' : ` --version ${selectedVersion}`;
-                        const cmd = `npx @nacos-group/cli${hostArg} agentspec-get ${quotedName}${versionArg}`;
+                        const cmd = buildNacosCliCommand({
+                          command: 'agentspec-get',
+                          resourceName: cliInfo.resourceName,
+                          server: cliInfo,
+                          version: isLatest ? undefined : selectedVersion,
+                        });
                         copyToClipboard(cmd).then(() => {
                           setCopiedCmd(true);
                           setTimeout(() => setCopiedCmd(false), 2000);
@@ -934,14 +934,16 @@ function WorkerDetail() {
                       style={{ fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace" }}
                     >
                       {(() => {
-                        const isDefaultHost = cliInfo.nacosHost === 'market.hiclaw.io';
-                        const hostArg = isDefaultHost ? '' : ` --host ${cliInfo.nacosHost}`;
                         const selectedVersionInfo = versions.find(
                           (v) => v.version === selectedVersion,
                         );
                         const isLatest = selectedVersionInfo?.isLatest ?? false;
-                        const versionArg = isLatest ? '' : ` --version ${selectedVersion}`;
-                        return `npx @nacos-group/cli${hostArg} agentspec-get ${cliInfo.resourceName.includes(' ') ? `"${cliInfo.resourceName}"` : cliInfo.resourceName}${versionArg}`;
+                        return buildNacosCliCommand({
+                          command: 'agentspec-get',
+                          resourceName: cliInfo.resourceName,
+                          server: cliInfo,
+                          version: isLatest ? undefined : selectedVersion,
+                        });
                       })()}
                     </code>
                   </div>


### PR DESCRIPTION
## 📝 Description

  - Added `nacosPort` to Skill CLI info typing so frontend can consume the port returned by backend.
  - Centralized Nacos CLI command generation for Skill and Worker downloads.
  - Included `--port` in generated `npx @nacos-group/cli` commands when Nacos CLI info provides a port.
  - Added tests for Nacos CLI command generation with custom host, port, quoted resource names, and output directory.

  ## 🔗 Related Issues

  Related to CLI download command generation for custom Nacos server URLs.

  ## ✅ Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Code refactoring (no functional changes)
  - [ ] Performance improvement
  - [ ] Build/CI configuration change
  - [ ] Other (please describe):

  ## 🧪 Testing

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing completed
  - [x] All tests pass locally

  Tested with:

  - `npm test -- src/lib/utils/nacosCliCommand.test.ts`
  - `npm run type-check`
  - `npm run lint`
  - `npm run format:check`
  - `npm run build`
  - Built and pushed Docker image `ekb-repo.tencentcloudcr.com/library/himarket-frontend:latest`

  ## 📋 Checklist

  - [ ] Code quality checks passed (run `./scripts/code-check.sh`)
  - [x] Code is self-reviewed
  - [ ] Comments added for complex code
  - [ ] Documentation updated (if applicable)
  - [x] No breaking changes (or migration guide provided)
  - [ ] All CI checks pass

  ## 📊 Test Coverage

  Added unit tests for Nacos CLI command generation, covering host and port arguments for Skill and Worker command usage.

  ## 📚 Additional Notes

  The backend already returns `nacosPort` from `displayServerUrl`; this change makes the frontend include that value in generated CLI commands.
<img width="918" height="934" alt="image" src="https://github.com/user-attachments/assets/628dbdcf-52b0-4380-a304-9cea289e7ce5" />
