### PR TITLE
fix: handle skill upload nacos limits

### DIFF
--- a/himarket-bootstrap/src/main/java/com/alibaba/himarket/config/JsonConfig.java
+++ b/himarket-bootstrap/src/main/java/com/alibaba/himarket/config/JsonConfig.java
@@ -17,14 +17,17 @@
  * under the License.
  */
 
-package com.alibaba.himarket.service.hicoding.sandbox;
+package com.alibaba.himarket.config;
 
-public record ConfigFile(String relativePath, String content, String contentHash, ConfigType type) {
+import com.alibaba.himarket.utils.JsonUtil;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
 
-    public enum ConfigType {
-        MODEL_SETTINGS,
-        MCP_CONFIG,
-        SKILL_CONFIG,
-        CUSTOM
+@Configuration
+public class JsonConfig {
+
+    @PostConstruct
+    void configureJsonDefaults() {
+        JsonUtil.configureDefaultStreamReadConstraints();
     }
 }

--- a/himarket-bootstrap/src/main/java/com/alibaba/himarket/config/WebSocketConfig.java
+++ b/himarket-bootstrap/src/main/java/com/alibaba/himarket/config/WebSocketConfig.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.config;
 
 import com.alibaba.himarket.service.hicoding.terminal.TerminalWebSocketHandler;

--- a/himarket-dal/src/main/java/com/alibaba/himarket/entity/CodingSession.java
+++ b/himarket-dal/src/main/java/com/alibaba/himarket/entity/CodingSession.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.entity;
 
 import jakarta.persistence.*;

--- a/himarket-dal/src/main/java/com/alibaba/himarket/repository/CodingSessionRepository.java
+++ b/himarket-dal/src/main/java/com/alibaba/himarket/repository/CodingSessionRepository.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.repository;
 
 import com.alibaba.himarket.entity.CodingSession;

--- a/himarket-dal/src/main/java/com/alibaba/himarket/utils/JsonUtil.java
+++ b/himarket-dal/src/main/java/com/alibaba/himarket/utils/JsonUtil.java
@@ -20,6 +20,7 @@
 package com.alibaba.himarket.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
@@ -42,7 +43,17 @@ import org.springframework.util.Assert;
 @Slf4j
 public class JsonUtil {
 
+    public static final int MAX_JSON_STRING_LENGTH = 50_000_000;
+
     public static final ObjectMapper DEFAULT_JSON_MAPPER = createDefaultJsonMapper();
+
+    /**
+     * Configures Jackson's JVM-wide default stream read constraints for ObjectMapper instances that
+     * are created outside JsonUtil.
+     */
+    public static void configureDefaultStreamReadConstraints() {
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(createStreamReadConstraints());
+    }
 
     /**
      * Creates default ObjectMapper instance.
@@ -62,6 +73,7 @@ public class JsonUtil {
     @NonNull
     public static ObjectMapper createJsonMapper(PropertyNamingStrategies.NamingBase strategy) {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.getFactory().setStreamReadConstraints(createStreamReadConstraints());
         mapper.registerModule(new JavaTimeModule());
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
@@ -69,6 +81,10 @@ public class JsonUtil {
             mapper.setPropertyNamingStrategy(strategy);
         }
         return mapper;
+    }
+
+    private static StreamReadConstraints createStreamReadConstraints() {
+        return StreamReadConstraints.builder().maxStringLength(MAX_JSON_STRING_LENGTH).build();
     }
 
     /**

--- a/himarket-server/src/main/java/com/alibaba/himarket/config/AcpProperties.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/config/AcpProperties.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.config;
 
 import com.alibaba.himarket.service.hicoding.sandbox.SandboxType;

--- a/himarket-server/src/main/java/com/alibaba/himarket/controller/CliProviderController.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/controller/CliProviderController.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.controller;
 
 import com.alibaba.himarket.config.AcpProperties;

--- a/himarket-server/src/main/java/com/alibaba/himarket/controller/CodingSessionController.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/controller/CodingSessionController.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.controller;
 
 import com.alibaba.himarket.core.annotation.DeveloperAuth;

--- a/himarket-server/src/main/java/com/alibaba/himarket/controller/SkillController.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/controller/SkillController.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.controller;
 
 import com.alibaba.himarket.core.annotation.AdminAuth;

--- a/himarket-server/src/main/java/com/alibaba/himarket/controller/WorkerController.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/controller/WorkerController.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.controller;
 
 import com.alibaba.himarket.core.annotation.AdminAuth;

--- a/himarket-server/src/main/java/com/alibaba/himarket/controller/WorkspaceController.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/controller/WorkspaceController.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.controller;
 
 import com.alibaba.himarket.core.annotation.AdminOrDeveloperAuth;

--- a/himarket-server/src/main/java/com/alibaba/himarket/core/agentspec/AgentSpecZipParser.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/core/agentspec/AgentSpecZipParser.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.core.agentspec;
 
 import cn.hutool.core.util.ArrayUtil;

--- a/himarket-server/src/main/java/com/alibaba/himarket/core/skill/FileTreeBuilder.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/core/skill/FileTreeBuilder.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.core.skill;
 
 import com.alibaba.himarket.dto.result.common.FileTreeNode;

--- a/himarket-server/src/main/java/com/alibaba/himarket/core/skill/SkillMdBuilder.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/core/skill/SkillMdBuilder.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.core.skill;
 
 import com.alibaba.nacos.api.ai.model.skills.Skill;

--- a/himarket-server/src/main/java/com/alibaba/himarket/core/skill/SkillZipParser.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/core/skill/SkillZipParser.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.core.skill;
 
 import com.alibaba.himarket.core.exception.BusinessException;
@@ -23,8 +42,8 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * ZIP 包解析工具类。参考 Nacos 服务端 SkillZipParser 实现。
- * 解析 ZIP → 提取 SKILL.md → 构建 Skill 对象。
+ * Utility for parsing Skill ZIP packages, based on the Nacos server SkillZipParser.
+ * Parses ZIP content, extracts SKILL.md, and builds a Skill object.
  */
 public final class SkillZipParser {
 
@@ -54,11 +73,11 @@ public final class SkillZipParser {
     }
 
     /**
-     * 解析 ZIP 包为 Nacos Skill 对象。
+     * Parses a ZIP package into a Nacos Skill object.
      *
-     * @param zipBytes ZIP 文件字节数组
-     * @param namespaceId Nacos 命名空间
-     * @return Skill 对象（含 name、description、instruction、resources）
+     * @param zipBytes ZIP file bytes
+     * @param namespaceId Nacos namespace
+     * @return Skill object containing name, description, instruction, and resources
      */
     public static Skill parseSkillFromZip(byte[] zipBytes, String namespaceId) {
         if (zipBytes == null || zipBytes.length == 0) {
@@ -68,7 +87,7 @@ public final class SkillZipParser {
         try {
             List<ZipEntryData> entries = unzipToEntries(zipBytes);
 
-            // 查找 SKILL.md（根目录或一级子目录）
+            // Find SKILL.md in the root directory or the first-level child directory.
             String skillMdContent = null;
             for (ZipEntryData entry : entries) {
                 if (isMacOsMetadataFile(entry.name)) continue;
@@ -94,6 +113,41 @@ public final class SkillZipParser {
         }
     }
 
+    /**
+     * Parses resource paths from a Skill ZIP without loading resource content.
+     *
+     * @param zipBytes ZIP file bytes
+     * @return Nacos Skill resource paths
+     */
+    public static List<String> parseResourcePathsFromZip(byte[] zipBytes) {
+        if (zipBytes == null || zipBytes.length == 0) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "ZIP file is empty");
+        }
+
+        try {
+            ZipManifest manifest = readZipManifest(zipBytes);
+            if (manifest.skillMdContent() == null || manifest.skillMdContent().isBlank()) {
+                throw new BusinessException(
+                        ErrorCode.INVALID_PARAMETER, "SKILL.md was not found in the ZIP package");
+            }
+
+            Skill skill = parseSkillMarkdown(manifest.skillMdContent(), "");
+            List<String> resourcePaths = new ArrayList<>();
+            for (String entryName : manifest.entryNames()) {
+                ResourcePath resourcePath = parseResourcePath(entryName, skill.getName());
+                if (resourcePath != null) {
+                    resourcePaths.add(resourcePath.path());
+                }
+            }
+            return resourcePaths;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(
+                    ErrorCode.INVALID_PARAMETER, "Failed to parse ZIP package: " + e.getMessage());
+        }
+    }
+
     private static List<ZipEntryData> unzipToEntries(byte[] zipBytes) throws IOException {
         List<ZipEntryData> result = new ArrayList<>();
         try (ZipArchiveInputStream zis =
@@ -107,17 +161,59 @@ public final class SkillZipParser {
             while ((entry = zis.getNextEntry()) != null) {
                 if (entry.isDirectory()) continue;
                 String name = entry.getName();
-                if (name != null && (name.contains("__MACOSX") || name.contains("/__MACOSX/")))
+                if (isIgnoredZipEntry(name)) {
+                    drainEntry(zis, buffer);
                     continue;
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-                int n;
-                while ((n = zis.read(buffer)) != -1) {
-                    out.write(buffer, 0, n);
                 }
-                result.add(new ZipEntryData(name, out.toByteArray()));
+                result.add(new ZipEntryData(name, readEntryBytes(zis, buffer)));
             }
         }
         return result;
+    }
+
+    private static ZipManifest readZipManifest(byte[] zipBytes) throws IOException {
+        List<String> entryNames = new ArrayList<>();
+        String skillMdContent = null;
+        try (ZipArchiveInputStream zis =
+                new ZipArchiveInputStream(
+                        new ByteArrayInputStream(zipBytes),
+                        StandardCharsets.UTF_8.name(),
+                        true,
+                        true)) {
+            ZipArchiveEntry entry;
+            byte[] buffer = new byte[8192];
+            while ((entry = zis.getNextEntry()) != null) {
+                if (entry.isDirectory()) continue;
+                String name = entry.getName();
+                if (isIgnoredZipEntry(name)) {
+                    drainEntry(zis, buffer);
+                    continue;
+                }
+                entryNames.add(name);
+                if (skillMdContent == null
+                        && (SKILL_MD_FILE.equals(name) || name.endsWith("/" + SKILL_MD_FILE))) {
+                    skillMdContent =
+                            new String(readEntryBytes(zis, buffer), StandardCharsets.UTF_8);
+                } else {
+                    drainEntry(zis, buffer);
+                }
+            }
+        }
+        return new ZipManifest(entryNames, skillMdContent);
+    }
+
+    private static byte[] readEntryBytes(ZipArchiveInputStream zis, byte[] buffer)
+            throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int n;
+        while ((n = zis.read(buffer)) != -1) {
+            out.write(buffer, 0, n);
+        }
+        return out.toByteArray();
+    }
+
+    private static void drainEntry(ZipArchiveInputStream zis, byte[] buffer) throws IOException {
+        while (zis.read(buffer) != -1) {}
     }
 
     private static Map<String, SkillResource> parseResources(
@@ -125,40 +221,12 @@ public final class SkillZipParser {
         Map<String, SkillResource> resources = new HashMap<>(16);
         for (ZipEntryData entry : entries) {
             String itemName = entry.name;
-            if (isMacOsMetadataFile(itemName)) continue;
-            if (itemName.endsWith(SKILL_MD_FILE) || itemName.endsWith("/")) continue;
-
-            String[] parts = itemName.split("/");
-            String type;
-            String resourceName;
-
-            if (parts.length == 1) {
-                type = "";
-                resourceName = parts[0];
-            } else if (parts.length == 2 && parts[0].equals(skillName)) {
-                type = "";
-                resourceName = parts[1];
-            } else if (parts.length >= 3 && parts[0].equals(skillName)) {
-                StringBuilder typeSb = new StringBuilder();
-                for (int i = 1; i < parts.length - 1; i++) {
-                    if (typeSb.length() > 0) typeSb.append('/');
-                    typeSb.append(parts[i]);
-                }
-                type = typeSb.toString();
-                resourceName = parts[parts.length - 1];
-            } else if (parts.length >= 2) {
-                StringBuilder typeSb = new StringBuilder();
-                for (int i = 0; i < parts.length - 1; i++) {
-                    if (typeSb.length() > 0) typeSb.append('/');
-                    typeSb.append(parts[i]);
-                }
-                type = typeSb.toString();
-                resourceName = parts[parts.length - 1];
-            } else {
+            ResourcePath path = parseResourcePath(itemName, skillName);
+            if (path == null) {
                 continue;
             }
 
-            boolean isBinary = isBinaryResource(resourceName);
+            boolean isBinary = isBinaryResource(path.name());
             String content;
             Map<String, Object> metadata = new HashMap<>(4);
             if (isBinary) {
@@ -169,14 +237,53 @@ public final class SkillZipParser {
             }
 
             SkillResource resource = new SkillResource();
-            resource.setName(resourceName);
-            resource.setType(type);
+            resource.setName(path.name());
+            resource.setType(path.type());
             resource.setContent(content);
             resource.setMetadata(metadata.isEmpty() ? null : metadata);
-            String key = SkillUtils.generateResourceId(type, resourceName);
+            String key = SkillUtils.generateResourceId(path.type(), path.name());
             resources.put(key, resource);
         }
         return resources;
+    }
+
+    private static ResourcePath parseResourcePath(String itemName, String skillName) {
+        if (itemName == null || itemName.isEmpty()) return null;
+        if (isMacOsMetadataFile(itemName)) return null;
+        if (itemName.endsWith(SKILL_MD_FILE) || itemName.endsWith("/")) return null;
+
+        String[] parts = itemName.split("/");
+        String type;
+        String name;
+
+        if (parts.length == 1) {
+            type = "";
+            name = parts[0];
+        } else if (parts.length == 2 && parts[0].equals(skillName)) {
+            type = "";
+            name = parts[1];
+        } else if (parts.length >= 3 && parts[0].equals(skillName)) {
+            type = joinPath(parts, 1, parts.length - 1);
+            name = parts[parts.length - 1];
+        } else if (parts.length >= 2) {
+            type = joinPath(parts, 0, parts.length - 1);
+            name = parts[parts.length - 1];
+        } else {
+            return null;
+        }
+
+        return new ResourcePath(type, name);
+    }
+
+    private static String joinPath(String[] parts, int startInclusive, int endExclusive) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = startInclusive; i < endExclusive; i++) {
+            if (builder.length() > 0) {
+                builder.append('/');
+            }
+            builder.append(parts[i]);
+        }
+        return builder.toString();
     }
 
     private static Skill parseSkillMarkdown(String markdownContent, String namespaceId) {
@@ -258,5 +365,23 @@ public final class SkillZipParser {
         return fileName.startsWith(MACOS_METADATA_PREFIX);
     }
 
+    private static boolean isIgnoredZipEntry(String itemName) {
+        return itemName == null
+                || itemName.contains("__MACOSX")
+                || itemName.contains("/__MACOSX/")
+                || isMacOsMetadataFile(itemName);
+    }
+
     private record ZipEntryData(String name, byte[] data) {}
+
+    private record ZipManifest(List<String> entryNames, String skillMdContent) {}
+
+    private record ResourcePath(String type, String name) {
+        String path() {
+            if (type == null || type.isBlank()) {
+                return name;
+            }
+            return type + "/" + name;
+        }
+    }
 }

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/coding/CreateCodingSessionParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/coding/CreateCodingSessionParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.coding;
 
 import com.alibaba.himarket.dto.converter.InputConverter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/coding/UpdateCodingSessionParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/coding/UpdateCodingSessionParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.coding;
 
 import com.alibaba.himarket.dto.converter.InputConverter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/mcp/McpConnectParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/mcp/McpConnectParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.mcp;
 
 import jakarta.validation.constraints.NotBlank;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/mcp/RegisterMcpParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/mcp/RegisterMcpParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.mcp;
 
 import jakarta.validation.constraints.NotBlank;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/mcp/SaveMcpEndpointParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/mcp/SaveMcpEndpointParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.mcp;
 
 import jakarta.validation.constraints.NotBlank;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/mcp/SaveMcpMetaParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/mcp/SaveMcpMetaParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.mcp;
 
 import jakarta.validation.constraints.NotBlank;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/mcp/SubscribeMcpParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/mcp/SubscribeMcpParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.mcp;
 
 import lombok.Data;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/product/ImportProductsParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/product/ImportProductsParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.product;
 
 import cn.hutool.core.util.StrUtil;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/product/UpdateProductSourceParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/product/UpdateProductSourceParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.product;
 
 import com.alibaba.himarket.support.enums.SourceType;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/worker/PublishWorkerVersionParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/worker/PublishWorkerVersionParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.worker;
 
 import jakarta.validation.constraints.NotBlank;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/worker/SetLatestWorkerVersionParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/worker/SetLatestWorkerVersionParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.worker;
 
 import jakarta.validation.constraints.NotBlank;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/params/worker/UpdateWorkerVersionStatusParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/params/worker/UpdateWorkerVersionStatusParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.params.worker;
 
 import jakarta.validation.constraints.NotBlank;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/coding/CodingSessionResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/coding/CodingSessionResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.coding;
 
 import com.alibaba.himarket.dto.converter.OutputConverter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/common/FileContentResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/common/FileContentResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.common;
 
 import lombok.AllArgsConstructor;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/common/FileTreeNode.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/common/FileTreeNode.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.common;
 
 import java.util.List;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/common/VersionResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/common/VersionResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.common;
 
 import com.alibaba.himarket.utils.JsonUtil;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/McpConnectResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/McpConnectResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.mcp;
 
 import lombok.AllArgsConstructor;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/McpEndpointResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/McpEndpointResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.mcp;
 
 import com.alibaba.himarket.dto.converter.OutputConverter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/McpMetaDetailResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/McpMetaDetailResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.mcp;
 
 import java.time.LocalDateTime;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/McpMetaResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/McpMetaResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.mcp;
 
 import com.alibaba.himarket.dto.converter.OutputConverter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/McpMetaSimpleResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/McpMetaSimpleResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.mcp;
 
 import java.time.LocalDateTime;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/MyEndpointResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/mcp/MyEndpointResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.mcp;
 
 import java.time.LocalDateTime;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/product/ImportProductsResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/product/ImportProductsResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.product;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/himarket-server/src/main/java/com/alibaba/himarket/dto/result/product/ProductImportResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/dto/result/product/ProductImportResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.dto.result.product;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/CodingSessionService.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/CodingSessionService.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service;
 
 import com.alibaba.himarket.dto.params.coding.CreateCodingSessionParam;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/McpSandboxDeployService.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/McpSandboxDeployService.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service;
 
 /**

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/SkillService.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/SkillService.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service;
 
 import com.alibaba.himarket.dto.result.cli.CliDownloadInfo;
@@ -17,8 +36,6 @@ import org.springframework.web.multipart.MultipartFile;
  * Direct Nacos operations are used by admin management endpoints.
  */
 public interface SkillService {
-
-    // ==================== Product-based operations ====================
 
     /**
      * Uploads a ZIP package and creates a new draft for the given product.

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/WorkerService.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/WorkerService.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service;
 
 import com.alibaba.himarket.dto.result.cli.CliDownloadInfo;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/document/DocumentConversionService.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/document/DocumentConversionService.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.document;
 
 import java.io.IOException;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/ModelEndpointResolver.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/ModelEndpointResolver.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.gateway;
 
 import java.util.List;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/service/OpenAILlmService.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/service/OpenAILlmService.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hichat.service;
 
 import cn.hutool.core.util.BooleanUtil;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/ChatBot.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/ChatBot.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hichat.support;
 
 import io.agentscope.core.ReActAgent;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/ChatContext.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/ChatContext.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hichat.support;
 
 import com.alibaba.himarket.dto.result.chat.LlmInvokeResult;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/InvokeModelParam.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/InvokeModelParam.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hichat.support;
 
 import com.alibaba.himarket.dto.result.consumer.CredentialContext;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/LlmChatRequest.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/LlmChatRequest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hichat.support;
 
 import com.alibaba.himarket.dto.result.product.ProductResult;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/ToolMeta.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hichat/support/ToolMeta.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hichat.support;
 
 import lombok.AllArgsConstructor;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/RemoteWorkspaceService.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/RemoteWorkspaceService.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding;
 
 import com.alibaba.himarket.config.AcpProperties;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/ClaudeCodeConfigGenerator.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/ClaudeCodeConfigGenerator.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.cli;
 
 import com.alibaba.himarket.service.hicoding.session.CustomModelConfig;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/CliConfigGenerator.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/CliConfigGenerator.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.cli;
 
 import com.alibaba.himarket.service.hicoding.session.CustomModelConfig;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/CliConfigGeneratorRegistry.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/CliConfigGeneratorRegistry.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.cli;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/ConfigFileBuilder.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/ConfigFileBuilder.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.cli;
 
 import com.alibaba.himarket.config.AcpProperties.CliProviderConfig;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/NacosEnvGenerator.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/NacosEnvGenerator.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.cli;
 
 import com.alibaba.himarket.service.hicoding.session.ResolvedSessionConfig;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/OpenCodeConfigGenerator.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/OpenCodeConfigGenerator.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.cli;
 
 import com.alibaba.himarket.service.hicoding.session.CustomModelConfig;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/ProtocolTypeMapper.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/ProtocolTypeMapper.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.cli;
 
 import java.util.List;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/QoderCliConfigGenerator.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/QoderCliConfigGenerator.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.cli;
 
 import com.alibaba.himarket.service.hicoding.session.CustomModelConfig;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/QwenCodeConfigGenerator.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/cli/QwenCodeConfigGenerator.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.cli;
 
 import com.alibaba.himarket.service.hicoding.session.CustomModelConfig;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/BaseUrlExtractor.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/BaseUrlExtractor.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.filesystem;
 
 import com.alibaba.himarket.dto.result.common.DomainResult;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/FileEntry.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/FileEntry.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.filesystem;
 
 /**

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/FileInfo.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/FileInfo.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.filesystem;
 
 /**

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/FileSystemAdapter.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/FileSystemAdapter.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.filesystem;
 
 import java.io.IOException;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/FileSystemException.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/FileSystemException.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.filesystem;
 
 import com.alibaba.himarket.service.hicoding.sandbox.SandboxType;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/PathValidator.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/PathValidator.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.filesystem;
 
 import java.nio.file.InvalidPathException;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/SidecarFileSystemAdapter.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/filesystem/SidecarFileSystemAdapter.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.filesystem;
 
 import com.alibaba.himarket.service.hicoding.sandbox.SandboxType;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/runtime/RemoteRuntimeAdapter.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/runtime/RemoteRuntimeAdapter.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.runtime;
 
 import com.alibaba.himarket.service.hicoding.filesystem.FileSystemAdapter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/runtime/RuntimeAdapter.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/runtime/RuntimeAdapter.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.runtime;
 
 import com.alibaba.himarket.service.hicoding.filesystem.FileSystemAdapter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/runtime/RuntimeConfig.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/runtime/RuntimeConfig.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.runtime;
 
 import java.util.List;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/runtime/RuntimeFaultNotification.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/runtime/RuntimeFaultNotification.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.runtime;
 
 import com.alibaba.himarket.service.hicoding.sandbox.SandboxType;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/runtime/RuntimeStatus.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/runtime/RuntimeStatus.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.runtime;
 
 /**

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/E2BSandboxProvider.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/E2BSandboxProvider.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox;
 
 import com.alibaba.himarket.service.hicoding.runtime.RuntimeAdapter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/ExecResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/ExecResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox;
 
 /**

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/OpenSandboxProvider.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/OpenSandboxProvider.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox;
 
 import com.alibaba.himarket.service.hicoding.runtime.RuntimeAdapter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/PodInfo.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/PodInfo.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox;
 
 import java.net.URI;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/RemoteSandboxProvider.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/RemoteSandboxProvider.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox;
 
 import com.alibaba.himarket.config.AcpProperties;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxConfig.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxConfig.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox;
 
 import java.util.Map;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxHttpClient.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxHttpClient.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxInfo.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxInfo.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxProvider.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxProvider.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox;
 
 import com.alibaba.himarket.service.hicoding.runtime.RuntimeAdapter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxProviderRegistry.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxProviderRegistry.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox;
 
 import java.util.List;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxType.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/SandboxType.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/ConfigInjectionPhase.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/ConfigInjectionPhase.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 import com.alibaba.himarket.service.hicoding.cli.ConfigFileBuilder;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/FileSystemReadyPhase.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/FileSystemReadyPhase.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 import com.alibaba.himarket.service.hicoding.sandbox.SandboxInfo;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitConfig.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitConfig.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 import java.time.Duration;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitContext.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitContext.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 import com.alibaba.himarket.config.AcpProperties.CliProviderConfig;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitErrorCode.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitErrorCode.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 /**

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitEvent.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 import java.time.Instant;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitPhase.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitPhase.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 /**

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitPhaseException.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitPhaseException.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 public class InitPhaseException extends RuntimeException {

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitResult.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/InitResult.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 import java.time.Duration;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/PhaseStatus.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/PhaseStatus.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 public enum PhaseStatus {

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/RetryPolicy.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/RetryPolicy.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 import java.time.Duration;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/SandboxAcquirePhase.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/SandboxAcquirePhase.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 import com.alibaba.himarket.service.hicoding.sandbox.SandboxInfo;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/SandboxInitPipeline.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/SandboxInitPipeline.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 import java.time.Duration;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/SidecarConnectPhase.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/SidecarConnectPhase.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 import com.alibaba.himarket.service.hicoding.runtime.RuntimeAdapter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/SkillDownloadPhase.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/sandbox/init/SkillDownloadPhase.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.sandbox.init;
 
 import com.alibaba.himarket.service.hicoding.sandbox.ExecResult;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/CliSessionConfig.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/CliSessionConfig.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.session;
 
 import java.util.List;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/CustomModelConfig.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/CustomModelConfig.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.session;
 
 import java.util.List;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/McpConfigResolver.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/McpConfigResolver.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.session;
 
 import com.alibaba.himarket.core.security.ContextHolder;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/ModelConfigResolver.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/ModelConfigResolver.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.session;
 
 import com.alibaba.himarket.dto.result.consumer.ConsumerCredentialResult;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/ResolvedSessionConfig.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/ResolvedSessionConfig.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.session;
 
 import java.util.List;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/SessionConfigResolver.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/SessionConfigResolver.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.session;
 
 import com.alibaba.himarket.entity.NacosInstance;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/SessionInitializer.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/session/SessionInitializer.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.session;
 
 import com.alibaba.himarket.config.AcpProperties.CliProviderConfig;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/terminal/RemoteTerminalBackend.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/terminal/RemoteTerminalBackend.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.terminal;
 
 import java.io.IOException;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/terminal/TerminalBackend.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/terminal/TerminalBackend.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.terminal;
 
 import java.io.IOException;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/terminal/TerminalProcess.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/terminal/TerminalProcess.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.terminal;
 
 import com.pty4j.PtyProcess;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/terminal/TerminalWebSocketHandler.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/terminal/TerminalWebSocketHandler.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.terminal;
 
 import com.alibaba.himarket.config.AcpProperties;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/CliProcess.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/CliProcess.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.websocket;
 
 import java.io.BufferedReader;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/HiCodingConnectionManager.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/HiCodingConnectionManager.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.websocket;
 
 import com.alibaba.himarket.config.AcpProperties;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/HiCodingHandshakeInterceptor.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/HiCodingHandshakeInterceptor.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.websocket;
 
 import cn.hutool.core.util.StrUtil;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/HiCodingMessageRouter.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/HiCodingMessageRouter.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.websocket;
 
 import com.alibaba.himarket.service.hicoding.runtime.RuntimeAdapter;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/HiCodingWebSocketHandler.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/HiCodingWebSocketHandler.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.websocket;
 
 import com.alibaba.himarket.config.AcpProperties;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/WebSocketPingScheduler.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/hicoding/websocket/WebSocketPingScheduler.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.hicoding.websocket;
 
 import java.util.concurrent.ConcurrentHashMap;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/CodingSessionServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/CodingSessionServiceImpl.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.impl;
 
 import com.alibaba.himarket.core.constant.Resources;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/McpSandboxDeployServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/McpSandboxDeployServiceImpl.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.impl;
 
 import com.alibaba.himarket.core.exception.BusinessException;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.impl;
 
 import cn.hutool.core.collection.CollUtil;
@@ -9,6 +28,7 @@ import com.alibaba.himarket.core.exception.ErrorCode;
 import com.alibaba.himarket.core.security.ContextHolder;
 import com.alibaba.himarket.core.skill.FileTreeBuilder;
 import com.alibaba.himarket.core.skill.SkillMdBuilder;
+import com.alibaba.himarket.core.skill.SkillZipParser;
 import com.alibaba.himarket.core.utils.IdGenerator;
 import com.alibaba.himarket.dto.converter.OutputConverter;
 import com.alibaba.himarket.dto.result.cli.CliDownloadInfo;
@@ -26,6 +46,7 @@ import com.alibaba.himarket.support.enums.ProductType;
 import com.alibaba.himarket.support.product.ProductFeature;
 import com.alibaba.himarket.support.product.SkillConfig;
 import com.alibaba.himarket.utils.JsonUtil;
+import com.alibaba.nacos.api.ai.model.NacosAiConfigKeyCodec;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
 import com.alibaba.nacos.api.ai.model.skills.SkillMeta;
 import com.alibaba.nacos.api.ai.model.skills.SkillResource;
@@ -59,6 +80,8 @@ public class SkillServiceImpl implements SkillService {
 
     private static final long MAX_ZIP_SIZE = 10 * 1024 * 1024;
 
+    private static final int NACOS_DATA_ID_MAX_LENGTH = 256;
+
     private final NacosService nacosService;
 
     private final ProductRepository productRepository;
@@ -80,17 +103,12 @@ public class SkillServiceImpl implements SkillService {
 
         if (StrUtil.isBlank(ref.getSkillName())) {
             // First upload: use overwrite mode in case Nacos already has a skill with the same name
-            String skillName =
-                    execute(
-                            ref.getNacosId(),
-                            s -> s.uploadSkillFromZip(ref.getNamespace(), zipBytes, true));
+            String skillName = uploadSkillZip(ref, zipBytes);
             log.info("Uploaded new Skill draft: {}", skillName);
             config.setSkillName(skillName);
         } else {
             // Subsequent upload: use overwrite mode to bypass reviewing version blocking
-            execute(
-                    ref.getNacosId(),
-                    s -> s.uploadSkillFromZip(ref.getNamespace(), zipBytes, true));
+            uploadSkillZip(ref, zipBytes);
             log.info("Uploaded (overwrite) for Skill {}", ref.getSkillName());
         }
 
@@ -516,25 +534,26 @@ public class SkillServiceImpl implements SkillService {
             throws IOException {
         SkillRef ref = getSkillRef(productId, true);
 
-        // 先调用 Nacos HTTP API 下载，让 Nacos 增加下载计数
+        // Download through the Nacos HTTP API so Nacos can increase the download count.
         downloadFromNacos(ref, version, response);
     }
 
     /**
-     * 通过调用 Nacos HTTP API 下载 Skill ZIP 包，使 Nacos 自动增加下载计数
+     * Downloads the Skill ZIP package through the Nacos HTTP API so Nacos can increase
+     * the download count automatically.
      * API: GET /v3/console/ai/skills/version/download?namespaceId=xxx&skillName=xxx&version=xxx
      */
     private void downloadFromNacos(SkillRef ref, String version, HttpServletResponse response)
             throws IOException {
         try {
             NacosInstance nacosInstance = nacosService.findNacosInstanceById(ref.getNacosId());
-            // 优先使用展示地址，不存在则使用 serverUrl
+            // Prefer the display URL and fall back to the server URL.
             String nacosBaseUrl =
                     StrUtil.isNotBlank(nacosInstance.getDisplayServerUrl())
                             ? nacosInstance.getDisplayServerUrl()
                             : nacosInstance.getServerUrl();
 
-            // 构建 Nacos 下载 URL:
+            // Build the Nacos download URL:
             // /v3/console/ai/skills/version/download?namespaceId=xxx&skillName=xxx&version=xxx
             StringBuilder urlBuilder = new StringBuilder();
             urlBuilder.append(nacosBaseUrl);
@@ -554,7 +573,7 @@ public class SkillServiceImpl implements SkillService {
                         .append(java.net.URLEncoder.encode(version, StandardCharsets.UTF_8.name()));
             }
 
-            // 添加认证参数（如果 Nacos 有用户名密码）
+            // Add authentication parameters if the Nacos instance has credentials.
             if (StrUtil.isNotBlank(nacosInstance.getUsername())
                     && StrUtil.isNotBlank(nacosInstance.getPassword())) {
                 urlBuilder
@@ -572,11 +591,11 @@ public class SkillServiceImpl implements SkillService {
             }
 
             String downloadUrl = urlBuilder.toString();
-            // 日志中密码脱敏
+            // Mask the password in logs.
             String loggedUrl = downloadUrl.replaceAll("password=[^&]+", "password=***");
             log.info("Calling Nacos download API: {}", loggedUrl);
 
-            // 创建 HTTP 连接
+            // Create the HTTP connection.
             java.net.URL url = new java.net.URL(downloadUrl);
             java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
@@ -585,7 +604,7 @@ public class SkillServiceImpl implements SkillService {
 
             int responseCode = conn.getResponseCode();
             if (responseCode == java.net.HttpURLConnection.HTTP_OK) {
-                // 设置响应头
+                // Set response headers.
                 response.setContentType("application/zip");
                 String encodedName =
                         java.net.URLEncoder.encode(
@@ -594,7 +613,7 @@ public class SkillServiceImpl implements SkillService {
                 response.setHeader(
                         "Content-Disposition", "attachment; filename*=UTF-8''" + encodedName);
 
-                // 流式传输 ZIP 文件
+                // Stream the ZIP file.
                 try (var input = conn.getInputStream();
                         var output = response.getOutputStream()) {
                     input.transferTo(output);
@@ -602,18 +621,18 @@ public class SkillServiceImpl implements SkillService {
                 log.info("Downloaded skill {} from Nacos successfully", ref.getSkillName());
             } else {
                 log.warn("Nacos download API returned non-OK status: {}", responseCode);
-                // 降级为本地生成 ZIP
+                // Fall back to local ZIP generation.
                 fallbackToLocalDownload(ref, version, response);
             }
         } catch (Exception e) {
             log.warn("Failed to download from Nacos, fallback to local generation", e);
-            // 降级为本地生成 ZIP
+            // Fall back to local ZIP generation.
             fallbackToLocalDownload(ref, version, response);
         }
     }
 
     /**
-     * 降级方案：本地生成 ZIP 包（不增加 Nacos 下载计数）
+     * Fallback path: generate the ZIP package locally without increasing the Nacos download count.
      */
     private void fallbackToLocalDownload(SkillRef ref, String version, HttpServletResponse response)
             throws IOException {
@@ -674,7 +693,14 @@ public class SkillServiceImpl implements SkillService {
 
     @Override
     public String uploadSkillFromZip(String nacosId, String namespace, byte[] zipBytes) {
+        validateSkillResourceDataIds(zipBytes);
         return execute(nacosId, s -> s.uploadSkillFromZip(namespace, zipBytes));
+    }
+
+    private String uploadSkillZip(SkillRef ref, byte[] zipBytes) {
+        validateSkillResourceDataIds(zipBytes);
+        return execute(
+                ref.getNacosId(), s -> s.uploadSkillFromZip(ref.getNamespace(), zipBytes, true));
     }
 
     /**
@@ -747,6 +773,27 @@ public class SkillServiceImpl implements SkillService {
             return type + "/" + name;
         }
         return name;
+    }
+
+    /**
+     * Validates resource paths before uploading to Nacos so overly long encoded data IDs fail with
+     * a clear parameter error instead of a database truncation error from Nacos.
+     */
+    private void validateSkillResourceDataIds(byte[] zipBytes) {
+        for (String resourcePath : SkillZipParser.parseResourcePathsFromZip(zipBytes)) {
+            String encodedPath = NacosAiConfigKeyCodec.encodeSegment(resourcePath);
+            if (encodedPath != null && encodedPath.length() > NACOS_DATA_ID_MAX_LENGTH) {
+                throw new BusinessException(
+                        ErrorCode.INVALID_PARAMETER,
+                        StrUtil.format(
+                                "Resource file path is too long. It is {} characters after Nacos"
+                                    + " encoding, which exceeds the {} character limit. Shorten the"
+                                    + " file name or reduce directory nesting: {}",
+                                encodedPath.length(),
+                                NACOS_DATA_ID_MAX_LENGTH,
+                                resourcePath));
+            }
+        }
     }
 
     private void writeZipEntry(ZipOutputStream zos, String path, byte[] data) throws IOException {

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/WorkerServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/WorkerServiceImpl.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.impl;
 
 import cn.hutool.core.collection.CollUtil;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/mcp/McpProtocolUtils.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/mcp/McpProtocolUtils.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.mcp;
 
 import cn.hutool.core.util.StrUtil;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/mcp/McpSandboxDeployStrategy.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/mcp/McpSandboxDeployStrategy.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.mcp;
 
 import com.alibaba.himarket.entity.SandboxInstance;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/mcp/SelfHostedDeployStrategy.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/mcp/SelfHostedDeployStrategy.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.mcp;
 
 import com.alibaba.himarket.entity.SandboxInstance;

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/task/DownloadCountSyncTask.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/task/DownloadCountSyncTask.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.alibaba.himarket.service.task;
 
 import cn.hutool.core.collection.CollUtil;


### PR DESCRIPTION
## 📝 Description

- Carry forward the Skill upload fixes from #282.
- Validate encoded Nacos resource paths before uploading Skill packages, so overlong `data_id` values return a clear `INVALID_PARAMETER` error before reaching the Nacos database layer.
- Increase the JVM-wide Jackson string read constraint for large Skill resources returned by the Nacos SDK.

## 🔗 Related Issues

Related to #278
Fix #279
Supersedes #282

## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All tests pass locally

Local checks:
- `./mvnw -pl himarket-bootstrap -am spotless:apply`
- `./mvnw -pl himarket-bootstrap -am -DskipTests compile`
- `git diff --check`

## 📋 Checklist

- [ ] Code quality checks passed (run `./scripts/code-check.sh`)
- [x] Code is self-reviewed
- [x] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

## 📊 Test Coverage

No automated tests were added. This carries forward a bug fix validated by local compile and formatting checks.

## 📚 Additional Notes

This PR is based on the contribution in #282. Thanks to @Rito-w for reporting and contributing the original fix direction.