### PR TITLE
fix: upgrade mcp java sdk for cve-2025-6514

### DIFF
--- a/himarket-server/pom.xml
+++ b/himarket-server/pom.xml
@@ -277,7 +277,16 @@
                     <artifactId>dashscope-sdk-java</artifactId>
                     <groupId>com.alibaba</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>mcp-json-jackson3</artifactId>
+                    <groupId>io.modelcontextprotocol.sdk</groupId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-json-jackson2</artifactId>
         </dependency>
 
         <dependency>

--- a/himarket-server/src/test/java/com/alibaba/himarket/service/hichat/manager/ChatBotManagerMcpCompatibilityTest.java
+++ b/himarket-server/src/test/java/com/alibaba/himarket/service/hichat/manager/ChatBotManagerMcpCompatibilityTest.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.alibaba.himarket.service.hichat.manager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.alibaba.himarket.dto.result.product.ProductResult;
+import com.alibaba.himarket.service.hichat.support.ChatBot;
+import com.alibaba.himarket.service.hichat.support.LlmChatRequest;
+import com.alibaba.himarket.support.chat.mcp.McpTransportConfig;
+import com.alibaba.himarket.support.enums.McpTransportMode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.agentscope.core.agent.Event;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+class ChatBotManagerMcpCompatibilityTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void shouldRegisterMcpToolsForChatBot() throws Exception {
+        MockMcpSseServer server = new MockMcpSseServer();
+        server.start();
+
+        try {
+            ToolManager toolManager = new ToolManager();
+            ChatBotManager chatBotManager = new ChatBotManager(toolManager);
+
+            ProductResult product = new ProductResult();
+            product.setProductId("model-product");
+            product.setName("test-model");
+
+            McpTransportConfig mcpConfig =
+                    McpTransportConfig.builder()
+                            .mcpServerName("mock-mcp")
+                            .productId("mcp-product")
+                            .transportMode(McpTransportMode.SSE)
+                            .url(server.sseUrl())
+                            .build();
+
+            LlmChatRequest request =
+                    LlmChatRequest.builder()
+                            .chatId("chat-1")
+                            .sessionId("session-1")
+                            .product(product)
+                            .historyMessages(List.of())
+                            .mcpConfigs(List.of(mcpConfig))
+                            .build();
+
+            StubModel model = new StubModel();
+            ChatBot chatBot = chatBotManager.getOrCreateChatBot(request, model);
+
+            assertNotNull(chatBot);
+            assertFalse(chatBot.isDegraded());
+            assertTrue(chatBot.getToolMetas().containsKey("echo"));
+            assertEquals("mock-mcp", chatBot.getToolMetas().get("echo").getMcpServerName());
+
+            List<Event> events =
+                    chatBot.chat(Msg.builder().role(MsgRole.USER).textContent("echo").build())
+                            .collectList()
+                            .block();
+
+            assertNotNull(events);
+            assertEquals(2, model.callCount());
+            assertEquals(1, server.toolCallCount());
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static final class StubModel implements Model {
+
+        private final AtomicInteger calls = new AtomicInteger();
+
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> toolSchemas, GenerateOptions options) {
+            if (calls.getAndIncrement() == 0) {
+                return Flux.just(
+                        ChatResponse.builder()
+                                .id("tool-call-response")
+                                .content(
+                                        List.of(
+                                                ToolUseBlock.builder()
+                                                        .id("call-1")
+                                                        .name("echo")
+                                                        .input(Map.of("text", "hello"))
+                                                        .content("{\"text\":\"hello\"}")
+                                                        .build()))
+                                .finishReason("tool_calls")
+                                .build());
+            }
+            return Flux.just(
+                    ChatResponse.builder()
+                            .id("final-response")
+                            .content(List.of(TextBlock.builder().text("done").build()))
+                            .finishReason("stop")
+                            .build());
+        }
+
+        @Override
+        public String getModelName() {
+            return "stub-model";
+        }
+
+        int callCount() {
+            return calls.get();
+        }
+    }
+
+    private static final class MockMcpSseServer {
+        private final HttpServer server;
+        private final ExecutorService executor = Executors.newCachedThreadPool();
+        private final CountDownLatch closeLatch = new CountDownLatch(1);
+        private final AtomicInteger toolCallCount = new AtomicInteger();
+        private final AtomicReference<OutputStream> sseStream = new AtomicReference<>();
+
+        MockMcpSseServer() throws IOException {
+            server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/sse", this::handleSse);
+            server.createContext("/message", this::handleMessage);
+            server.setExecutor(executor);
+        }
+
+        void start() {
+            server.start();
+        }
+
+        String sseUrl() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/sse";
+        }
+
+        int toolCallCount() {
+            return toolCallCount.get();
+        }
+
+        void stop() {
+            closeLatch.countDown();
+            server.stop(0);
+            executor.shutdownNow();
+        }
+
+        private void handleSse(HttpExchange exchange) throws IOException {
+            exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
+            exchange.getResponseHeaders().set("Cache-Control", "no-cache");
+            exchange.sendResponseHeaders(200, 0);
+
+            OutputStream body = exchange.getResponseBody();
+            sseStream.set(body);
+            writeSse(body, "endpoint", "/message");
+            try {
+                closeLatch.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                body.close();
+                exchange.close();
+            }
+        }
+
+        private void handleMessage(HttpExchange exchange) throws IOException {
+            JsonNode request = MAPPER.readTree(exchange.getRequestBody());
+            if (request.has("id")) {
+                writeSse(sseStream.get(), "message", responseFor(request, toolCallCount));
+            }
+            exchange.sendResponseHeaders(202, 2);
+            exchange.getResponseBody().write("{}".getBytes(StandardCharsets.UTF_8));
+            exchange.close();
+        }
+
+        private static String responseFor(JsonNode request, AtomicInteger toolCallCount)
+                throws IOException {
+            ObjectNode response = MAPPER.createObjectNode();
+            response.put("jsonrpc", "2.0");
+            response.set("id", request.get("id"));
+
+            String method = request.path("method").asText();
+            ObjectNode result = response.putObject("result");
+            if ("initialize".equals(method)) {
+                result.put("protocolVersion", "2024-11-05");
+                result.putObject("capabilities").putObject("tools");
+                result.putObject("serverInfo").put("name", "mock").put("version", "1.0.0");
+            } else if ("tools/list".equals(method)) {
+                ObjectNode tool = result.putArray("tools").addObject();
+                tool.put("name", "echo");
+                tool.put("description", "Echo input text");
+                ObjectNode schema = tool.putObject("inputSchema");
+                schema.put("type", "object");
+                schema.putObject("properties")
+                        .putObject("text")
+                        .put("type", "string")
+                        .put("description", "Text to echo");
+                schema.putArray("required").add("text");
+            } else if ("tools/call".equals(method)) {
+                toolCallCount.incrementAndGet();
+                String text = request.path("params").path("arguments").path("text").asText();
+                ObjectNode content = result.putArray("content").addObject();
+                content.put("type", "text");
+                content.put("text", text);
+                result.put("isError", false);
+            }
+            return MAPPER.writeValueAsString(response);
+        }
+
+        private static void writeSse(OutputStream stream, String event, String data)
+                throws IOException {
+            stream.write(("event: " + event + "\n").getBytes(StandardCharsets.UTF_8));
+            stream.write(("data: " + data + "\n\n").getBytes(StandardCharsets.UTF_8));
+            stream.flush();
+        }
+    }
+}

--- a/himarket-server/src/test/java/com/alibaba/himarket/service/hichat/manager/McpClientBuilderCompatibilityTest.java
+++ b/himarket-server/src/test/java/com/alibaba/himarket/service/hichat/manager/McpClientBuilderCompatibilityTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.alibaba.himarket.service.hichat.manager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.agentscope.core.tool.mcp.McpClientBuilder;
+import io.agentscope.core.tool.mcp.McpClientWrapper;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class McpClientBuilderCompatibilityTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void shouldInitializeAndListToolsWithManagedMcpSdk() throws Exception {
+        MockMcpSseServer server = new MockMcpSseServer();
+        server.start();
+
+        McpClientWrapper client =
+                McpClientBuilder.create("compat")
+                        .sseTransport(server.sseUrl())
+                        .timeout(Duration.ofSeconds(5))
+                        .buildSync();
+
+        try {
+            assertNotNull(client);
+            assertEquals("compat", client.getName());
+            client.initialize().block(Duration.ofSeconds(5));
+
+            List<McpSchema.Tool> tools = client.listTools().block(Duration.ofSeconds(5));
+
+            assertNotNull(tools);
+            assertEquals(1, tools.size());
+            assertEquals("echo", tools.get(0).name());
+
+            McpSchema.CallToolResult callResult =
+                    client.callTool("echo", java.util.Map.of("text", "hello"))
+                            .block(Duration.ofSeconds(5));
+
+            assertNotNull(callResult);
+            assertFalse(Boolean.TRUE.equals(callResult.isError()));
+            assertEquals(1, callResult.content().size());
+            assertEquals("hello", ((McpSchema.TextContent) callResult.content().get(0)).text());
+        } finally {
+            client.close();
+            server.stop();
+        }
+    }
+
+    private static final class MockMcpSseServer {
+        private final HttpServer server;
+        private final ExecutorService executor = Executors.newCachedThreadPool();
+        private final CountDownLatch closeLatch = new CountDownLatch(1);
+        private final AtomicReference<OutputStream> sseStream = new AtomicReference<>();
+
+        MockMcpSseServer() throws IOException {
+            server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/sse", this::handleSse);
+            server.createContext("/message", this::handleMessage);
+            server.setExecutor(executor);
+        }
+
+        void start() {
+            server.start();
+        }
+
+        String sseUrl() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/sse";
+        }
+
+        void stop() {
+            closeLatch.countDown();
+            server.stop(0);
+            executor.shutdownNow();
+        }
+
+        private void handleSse(HttpExchange exchange) throws IOException {
+            exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
+            exchange.getResponseHeaders().set("Cache-Control", "no-cache");
+            exchange.sendResponseHeaders(200, 0);
+
+            OutputStream body = exchange.getResponseBody();
+            sseStream.set(body);
+            writeSse(body, "endpoint", "/message");
+            try {
+                closeLatch.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                body.close();
+                exchange.close();
+            }
+        }
+
+        private void handleMessage(HttpExchange exchange) throws IOException {
+            JsonNode request = MAPPER.readTree(exchange.getRequestBody());
+            if (request.has("id")) {
+                writeSse(sseStream.get(), "message", responseFor(request));
+            }
+            exchange.sendResponseHeaders(202, 2);
+            exchange.getResponseBody().write("{}".getBytes(StandardCharsets.UTF_8));
+            exchange.close();
+        }
+
+        private static String responseFor(JsonNode request) throws IOException {
+            ObjectNode response = MAPPER.createObjectNode();
+            response.put("jsonrpc", "2.0");
+            response.set("id", request.get("id"));
+
+            String method = request.path("method").asText();
+            ObjectNode result = response.putObject("result");
+            if ("initialize".equals(method)) {
+                result.put("protocolVersion", "2024-11-05");
+                result.putObject("capabilities").putObject("tools");
+                result.putObject("serverInfo").put("name", "mock").put("version", "1.0.0");
+            } else if ("tools/list".equals(method)) {
+                ObjectNode tool = result.putArray("tools").addObject();
+                tool.put("name", "echo");
+                tool.put("description", "Echo input text");
+                ObjectNode schema = tool.putObject("inputSchema");
+                schema.put("type", "object");
+                schema.putObject("properties")
+                        .putObject("text")
+                        .put("type", "string")
+                        .put("description", "Text to echo");
+                schema.putArray("required").add("text");
+            } else if ("tools/call".equals(method)) {
+                String text = request.path("params").path("arguments").path("text").asText();
+                ObjectNode content = result.putArray("content").addObject();
+                content.put("type", "text");
+                content.put("text", text);
+                result.put("isError", false);
+            }
+            return MAPPER.writeValueAsString(response);
+        }
+
+        private static void writeSse(OutputStream stream, String event, String data)
+                throws IOException {
+            stream.write(("event: " + event + "\n").getBytes(StandardCharsets.UTF_8));
+            stream.write(("data: " + data + "\n\n").getBytes(StandardCharsets.UTF_8));
+            stream.flush();
+        }
+    }
+}

--- a/himarket-server/src/test/java/com/alibaba/himarket/service/impl/McpAffectedEntryCompatibilityTest.java
+++ b/himarket-server/src/test/java/com/alibaba/himarket/service/impl/McpAffectedEntryCompatibilityTest.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.alibaba.himarket.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.alibaba.himarket.core.security.ContextHolder;
+import com.alibaba.himarket.dto.result.common.DomainResult;
+import com.alibaba.himarket.dto.result.mcp.McpConfigResult;
+import com.alibaba.himarket.entity.McpServerMeta;
+import com.alibaba.himarket.entity.Product;
+import com.alibaba.himarket.entity.ProductRef;
+import com.alibaba.himarket.repository.ApiDefinitionRepository;
+import com.alibaba.himarket.repository.ConsumerRepository;
+import com.alibaba.himarket.repository.McpServerEndpointRepository;
+import com.alibaba.himarket.repository.McpServerMetaRepository;
+import com.alibaba.himarket.repository.ProductPublicationRepository;
+import com.alibaba.himarket.repository.ProductRefRepository;
+import com.alibaba.himarket.repository.ProductRepository;
+import com.alibaba.himarket.repository.SubscriptionRepository;
+import com.alibaba.himarket.service.GatewayService;
+import com.alibaba.himarket.service.NacosService;
+import com.alibaba.himarket.service.PortalService;
+import com.alibaba.himarket.service.ProductCategoryService;
+import com.alibaba.himarket.service.SkillService;
+import com.alibaba.himarket.service.WorkerService;
+import com.alibaba.himarket.service.hichat.manager.ToolManager;
+import com.alibaba.himarket.service.mcp.McpConfigSyncHelper;
+import com.alibaba.himarket.service.mcp.McpSandboxOrchestrator;
+import com.alibaba.himarket.service.mcp.McpTransportResolver;
+import com.alibaba.himarket.support.api.spec.OpenAPIToolsConfig;
+import com.alibaba.himarket.support.enums.McpProtocolType;
+import com.alibaba.himarket.support.enums.ProductType;
+import com.alibaba.himarket.support.enums.SourceType;
+import com.alibaba.himarket.utils.JsonUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class McpAffectedEntryCompatibilityTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void productSyncShouldFetchAndPersistMcpSdkTools() throws Exception {
+        MockMcpSseServer server = new MockMcpSseServer();
+        server.start();
+
+        try {
+            ProductServiceImpl productService = newProductService(new ToolManager());
+            Product product =
+                    Product.builder()
+                            .productId("mcp-product")
+                            .name("mock-mcp")
+                            .type(ProductType.MCP_SERVER)
+                            .build();
+            ProductRef productRef =
+                    ProductRef.builder()
+                            .productId("mcp-product")
+                            .sourceType(SourceType.CUSTOM)
+                            .mcpConfig(mcpConfigJson("mock-mcp", server))
+                            .build();
+
+            invokePrivate(
+                    productService,
+                    "syncMcpTools",
+                    new Class<?>[] {Product.class, ProductRef.class},
+                    product,
+                    productRef);
+
+            McpConfigResult updated =
+                    JsonUtil.parse(productRef.getMcpConfig(), McpConfigResult.class);
+            OpenAPIToolsConfig tools = JsonUtil.parse(updated.getTools(), OpenAPIToolsConfig.class);
+
+            assertNotNull(tools);
+            assertEquals("mock-mcp", tools.getServer().getName());
+            assertEquals(1, tools.getTools().size());
+            assertEquals("echo", tools.getTools().get(0).getName());
+            assertEquals("text", tools.getTools().get(0).getArgs().get(0).getName());
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    void mcpServerRefreshShouldFetchAndSaveSdkTools() throws Exception {
+        MockMcpSseServer server = new MockMcpSseServer();
+        server.start();
+        McpServerMetaRepository metaRepository = mock(McpServerMetaRepository.class);
+
+        try {
+            McpServerServiceImpl mcpServerService =
+                    new McpServerServiceImpl(
+                            metaRepository,
+                            mock(McpServerEndpointRepository.class),
+                            mock(ProductRepository.class),
+                            mock(ProductPublicationRepository.class),
+                            mock(ContextHolder.class),
+                            new ToolManager(),
+                            mock(McpConfigSyncHelper.class),
+                            mock(McpSandboxOrchestrator.class),
+                            mock(McpTransportResolver.class));
+            McpServerMeta meta =
+                    McpServerMeta.builder()
+                            .mcpServerId("mcp-1")
+                            .productId("product-1")
+                            .mcpName("mock-mcp")
+                            .build();
+
+            invokePrivate(
+                    mcpServerService,
+                    "fetchAndSaveToolsListOrThrow",
+                    new Class<?>[] {McpServerMeta.class, String.class, String.class},
+                    meta,
+                    server.sseUrl(),
+                    "sse");
+
+            assertNotNull(meta.getToolsConfig());
+            assertTrue(meta.getToolsConfig().contains("\"name\":\"echo\""));
+            verify(metaRepository).save(meta);
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static ProductServiceImpl newProductService(ToolManager toolManager) {
+        return new ProductServiceImpl(
+                mock(ContextHolder.class),
+                mock(PortalService.class),
+                mock(GatewayService.class),
+                mock(ProductRepository.class),
+                mock(ProductRefRepository.class),
+                mock(ApiDefinitionRepository.class),
+                mock(ProductPublicationRepository.class),
+                mock(SubscriptionRepository.class),
+                mock(ConsumerRepository.class),
+                mock(NacosService.class),
+                mock(ProductCategoryService.class),
+                toolManager,
+                mock(WorkerService.class),
+                mock(SkillService.class));
+    }
+
+    private static String mcpConfigJson(String serverName, MockMcpSseServer server) {
+        McpConfigResult config = new McpConfigResult();
+        config.setMcpServerName(serverName);
+        config.setProtocol(McpProtocolType.SSE);
+
+        McpConfigResult.McpServerConfig serverConfig = new McpConfigResult.McpServerConfig();
+        serverConfig.setPath("/sse");
+        serverConfig.setDomains(
+                List.of(
+                        DomainResult.builder()
+                                .protocol("http")
+                                .domain("127.0.0.1")
+                                .port(server.port())
+                                .networkType("internet")
+                                .build()));
+        config.setMcpServerConfig(serverConfig);
+
+        return JsonUtil.toJson(config);
+    }
+
+    private static Object invokePrivate(
+            Object target, String methodName, Class<?>[] parameterTypes, Object... args)
+            throws Exception {
+        Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(target, args);
+    }
+
+    private static final class MockMcpSseServer {
+        private final HttpServer server;
+        private final ExecutorService executor = Executors.newCachedThreadPool();
+        private final CountDownLatch closeLatch = new CountDownLatch(1);
+        private final AtomicReference<OutputStream> sseStream = new AtomicReference<>();
+
+        MockMcpSseServer() throws IOException {
+            server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/sse", this::handleSse);
+            server.createContext("/message", this::handleMessage);
+            server.setExecutor(executor);
+        }
+
+        void start() {
+            server.start();
+        }
+
+        int port() {
+            return server.getAddress().getPort();
+        }
+
+        String sseUrl() {
+            return "http://127.0.0.1:" + port() + "/sse";
+        }
+
+        void stop() {
+            closeLatch.countDown();
+            server.stop(0);
+            executor.shutdownNow();
+        }
+
+        private void handleSse(HttpExchange exchange) throws IOException {
+            exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
+            exchange.getResponseHeaders().set("Cache-Control", "no-cache");
+            exchange.sendResponseHeaders(200, 0);
+
+            OutputStream body = exchange.getResponseBody();
+            sseStream.set(body);
+            writeSse(body, "endpoint", "/message");
+            try {
+                closeLatch.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                body.close();
+                exchange.close();
+            }
+        }
+
+        private void handleMessage(HttpExchange exchange) throws IOException {
+            JsonNode request = MAPPER.readTree(exchange.getRequestBody());
+            if (request.has("id")) {
+                writeSse(sseStream.get(), "message", responseFor(request));
+            }
+            exchange.sendResponseHeaders(202, 2);
+            exchange.getResponseBody().write("{}".getBytes(StandardCharsets.UTF_8));
+            exchange.close();
+        }
+
+        private static String responseFor(JsonNode request) throws IOException {
+            ObjectNode response = MAPPER.createObjectNode();
+            response.put("jsonrpc", "2.0");
+            response.set("id", request.get("id"));
+
+            String method = request.path("method").asText();
+            ObjectNode result = response.putObject("result");
+            if ("initialize".equals(method)) {
+                result.put("protocolVersion", "2024-11-05");
+                result.putObject("capabilities").putObject("tools");
+                result.putObject("serverInfo").put("name", "mock").put("version", "1.0.0");
+            } else if ("tools/list".equals(method)) {
+                ObjectNode tool = result.putArray("tools").addObject();
+                tool.put("name", "echo");
+                tool.put("description", "Echo input text");
+                ObjectNode schema = tool.putObject("inputSchema");
+                schema.put("type", "object");
+                schema.putObject("properties")
+                        .putObject("text")
+                        .put("type", "string")
+                        .put("description", "Text to echo");
+                schema.putArray("required").add("text");
+            }
+            return MAPPER.writeValueAsString(response);
+        }
+
+        private static void writeSse(OutputStream stream, String event, String data)
+                throws IOException {
+            stream.write(("event: " + event + "\n").getBytes(StandardCharsets.UTF_8));
+            stream.write(("data: " + data + "\n\n").getBytes(StandardCharsets.UTF_8));
+            stream.flush();
+        }
+    }
+}

--- a/himarket-server/src/test/java/com/alibaba/himarket/support/mcp/OpenAPIToolsConfigConverterTest.java
+++ b/himarket-server/src/test/java/com/alibaba/himarket/support/mcp/OpenAPIToolsConfigConverterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.alibaba.himarket.support.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.alibaba.himarket.support.api.spec.OpenAPIToolsConfig;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OpenAPIToolsConfigConverterTest {
+
+    @Test
+    void shouldConvertMcpSdkJsonSchemaInputSchema() {
+        McpSchema.JsonSchema inputSchema =
+                new McpSchema.JsonSchema(
+                        "object",
+                        Map.of("query", Map.of("type", "string", "description", "Search query")),
+                        List.of("query"),
+                        null,
+                        null,
+                        null);
+        McpSchema.Tool tool =
+                McpSchema.Tool.builder()
+                        .name("search")
+                        .description("Search documents")
+                        .inputSchema(inputSchema)
+                        .build();
+
+        OpenAPIToolsConfig config =
+                OpenAPIToolsConfigConverter.convertFromToolList("docs", List.of(tool));
+
+        assertEquals("docs", config.getServer().getName());
+        assertEquals(1, config.getTools().size());
+        assertEquals("search", config.getTools().get(0).getName());
+        assertEquals(1, config.getTools().get(0).getArgs().size());
+        OpenAPIToolsConfig.Arg arg = config.getTools().get(0).getArgs().get(0);
+        assertEquals("query", arg.getName());
+        assertEquals("string", arg.getType());
+        assertEquals("Search query", arg.getDescription());
+        assertTrue(arg.isRequired());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <fabric8.version>6.1.1</fabric8.version>
         <agentscope.version>1.0.10</agentscope.version>
+        <modelcontextprotocol.version>1.1.3</modelcontextprotocol.version>
         <jackson-databind.version>2.17.2</jackson-databind.version>
         <openai.java.version>4.6.1</openai.java.version>
         <dashscope.java.version>2.22.4</dashscope.java.version>
@@ -259,6 +260,21 @@
                 <groupId>io.agentscope</groupId>
                 <artifactId>agentscope</artifactId>
                 <version>${agentscope.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.modelcontextprotocol.sdk</groupId>
+                <artifactId>mcp</artifactId>
+                <version>${modelcontextprotocol.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.modelcontextprotocol.sdk</groupId>
+                <artifactId>mcp-core</artifactId>
+                <version>${modelcontextprotocol.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.modelcontextprotocol.sdk</groupId>
+                <artifactId>mcp-json-jackson2</artifactId>
+                <version>${modelcontextprotocol.version}</version>
             </dependency>
 
             <!-- OpenAI Java SDK -->


### PR DESCRIPTION
## 📝 Description

- Upgrade `io.modelcontextprotocol.sdk` to `1.1.3` to address `CVE-2025-6514`.
- The vulnerable MCP Java SDK version was introduced transitively through `io.agentscope:agentscope`, so this PR manages MCP SDK artifacts explicitly in the root dependency management.
- Exclude `mcp-json-jackson3` and add `mcp-json-jackson2` explicitly because HiMarket currently uses the Jackson 2.17.2 stack. This avoids runtime compatibility issues such as `NoSuchMethodError` from the Jackson 3 adapter.
- Add regression coverage for affected MCP paths:
  - MCP client initialization, `listTools`, and `callTool`
  - chat-triggered MCP tool calls
  - MCP `refresh-tools` metadata sync
  - product MCP tool sync
  - `McpSchema.Tool` to `OpenAPIToolsConfig` conversion

## 🔗 Related Issues

N/A

## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests pass locally

Validation performed:
- `./scripts/code-check.sh`
- `mvn -q test`
- `git diff --check`
- Manual smoke test for chat-triggered MCP tool invocation with a real model and local mock MCP SSE server

## 📋 Checklist

- [x] Code quality checks passed (run `./scripts/code-check.sh`)
- [x] Code is self-reviewed
- [ ] Comments added for complex code
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

## 📊 Test Coverage

- Added regression tests for all direct MCP SDK usage paths in this change.
- Covered MCP client creation, tool listing, tool calling, chat MCP execution, refresh-tools sync, product tool sync, and schema conversion.
- Existing full local test suite passes.

## 📚 Additional Notes

- No production Java business logic was changed.
- The dependency change intentionally keeps the MCP SDK on the Jackson 2 adapter to match the existing project runtime.