### PR TITLE
fix: reuse existing gateway consumer refs

### DIFF
--- a/himarket-dal/src/main/java/com/alibaba/himarket/repository/ConsumerRefRepository.java
+++ b/himarket-dal/src/main/java/com/alibaba/himarket/repository/ConsumerRefRepository.java
@@ -22,6 +22,7 @@ package com.alibaba.himarket.repository;
 import com.alibaba.himarket.entity.ConsumerRef;
 import com.alibaba.himarket.support.enums.GatewayType;
 import java.util.List;
+import org.springframework.data.domain.Sort;
 
 public interface ConsumerRefRepository extends BaseRepository<ConsumerRef, Long> {
 
@@ -38,7 +39,9 @@ public interface ConsumerRefRepository extends BaseRepository<ConsumerRef, Long>
      *
      * @param consumerId the consumer ID
      * @param gatewayType the gateway type
+     * @param sort the sort order
      * @return the list of consumer references
      */
-    List<ConsumerRef> findAllByConsumerIdAndGatewayType(String consumerId, GatewayType gatewayType);
+    List<ConsumerRef> findAllByConsumerIdAndGatewayType(
+            String consumerId, GatewayType gatewayType, Sort sort);
 }

--- a/himarket-dal/src/main/java/com/alibaba/himarket/support/gateway/APIGConfig.java
+++ b/himarket-dal/src/main/java/com/alibaba/himarket/support/gateway/APIGConfig.java
@@ -41,4 +41,12 @@ public class APIGConfig {
                 && StrUtil.isNotBlank(secretKey)
                 && StrUtil.isNotBlank(region);
     }
+
+    public boolean matchesGatewayIdentity(APIGConfig other) {
+        return other != null
+                && StrUtil.isNotBlank(accessKey)
+                && StrUtil.isNotBlank(region)
+                && StrUtil.equals(accessKey, other.getAccessKey())
+                && StrUtil.equals(region, other.getRegion());
+    }
 }

--- a/himarket-dal/src/main/java/com/alibaba/himarket/support/gateway/HigressConfig.java
+++ b/himarket-dal/src/main/java/com/alibaba/himarket/support/gateway/HigressConfig.java
@@ -63,4 +63,24 @@ public class HigressConfig {
 
         return true;
     }
+
+    public boolean matchesGatewayIdentity(HigressConfig other) {
+        String normalizedAddress = normalizeAddress(address);
+        return other != null
+                && StrUtil.isNotBlank(normalizedAddress)
+                && StrUtil.equals(normalizedAddress, normalizeAddress(other.getAddress()));
+    }
+
+    private static String normalizeAddress(String address) {
+        String trimmedAddress = StrUtil.trim(address);
+        if (StrUtil.isBlank(trimmedAddress)) {
+            return null;
+        }
+
+        String addressWithScheme =
+                StrUtil.startWithAnyIgnoreCase(trimmedAddress, "http://", "https://")
+                        ? trimmedAddress
+                        : "http://" + trimmedAddress;
+        return StrUtil.removeSuffix(addressWithScheme, "/");
+    }
 }

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/ConsumerServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/ConsumerServiceImpl.java
@@ -55,9 +55,12 @@ import com.alibaba.himarket.support.consumer.ApiKeyConfig;
 import com.alibaba.himarket.support.consumer.ConsumerAuthConfig;
 import com.alibaba.himarket.support.consumer.HmacConfig;
 import com.alibaba.himarket.support.enums.CredentialMode;
+import com.alibaba.himarket.support.enums.GatewayType;
 import com.alibaba.himarket.support.enums.SourceType;
 import com.alibaba.himarket.support.enums.SubscriptionStatus;
+import com.alibaba.himarket.support.gateway.APIGConfig;
 import com.alibaba.himarket.support.gateway.GatewayConfig;
+import com.alibaba.himarket.support.gateway.HigressConfig;
 import com.alibaba.himarket.utils.JsonUtil;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
@@ -697,17 +700,37 @@ public class ConsumerServiceImpl implements ConsumerService {
     }
 
     private ConsumerRef matchConsumerRef(String consumerId, GatewayConfig gatewayConfig) {
+        GatewayType gatewayType = gatewayConfig.getGatewayType();
         List<ConsumerRef> consumeRefs =
                 consumerRefRepository.findAllByConsumerIdAndGatewayType(
-                        consumerId, gatewayConfig.getGatewayType());
-        if (consumeRefs.isEmpty()) {
-            return null;
-        }
+                        consumerId, gatewayType, Sort.by(Sort.Direction.ASC, "id"));
 
         for (ConsumerRef ref : consumeRefs) {
-            // Check if the gateway config matches
-            if (StrUtil.equals(
-                    JsonUtil.toJson(ref.getGatewayConfig()), JsonUtil.toJson(gatewayConfig))) {
+            GatewayConfig refGatewayConfig = ref.getGatewayConfig();
+            if (refGatewayConfig == null) {
+                continue;
+            }
+
+            boolean matched =
+                    switch (gatewayType) {
+                        case APIG_API, APIG_AI -> {
+                            APIGConfig apigConfig = gatewayConfig.getApigConfig();
+                            yield apigConfig != null
+                                    && apigConfig.matchesGatewayIdentity(
+                                            refGatewayConfig.getApigConfig());
+                        }
+                        case HIGRESS -> {
+                            HigressConfig higressConfig = gatewayConfig.getHigressConfig();
+                            yield higressConfig != null
+                                    && higressConfig.matchesGatewayIdentity(
+                                            refGatewayConfig.getHigressConfig());
+                        }
+                        default ->
+                                StrUtil.equals(
+                                        JsonUtil.toJson(refGatewayConfig),
+                                        JsonUtil.toJson(gatewayConfig));
+                    };
+            if (matched) {
                 return ref;
             }
         }


### PR DESCRIPTION
## Description

- Reuse existing gateway consumer references with stable gateway identity matching to avoid creating duplicate gateway consumers after upgrades.
- Match APIG gateway identity by access key and region, and match Higress gateway identity by normalized address.
- Sort ConsumerRef candidates by ID so the earliest reference is preferred when historical duplicates exist.

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] git diff --check
- [x] make compile