### PR TITLE
fix(admin): restore admin login flow

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/AIGWOperator.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/AIGWOperator.java
@@ -128,7 +128,9 @@ public class AIGWOperator extends APIGOperator {
 
         String path = resp.getMcpServerPath();
         String exposedUriPath = resp.getExposedUriPath();
-        if (StrUtil.isNotBlank(exposedUriPath)) {
+        boolean protocolCompatible =
+                StrUtil.equalsIgnoreCase(resp.getCreateFromType(), "ApiGatewayProxyMcpHosting");
+        if (!protocolCompatible && StrUtil.isNotBlank(exposedUriPath)) {
             path += exposedUriPath;
         }
         serverConfig.setPath(path);
@@ -153,9 +155,12 @@ public class AIGWOperator extends APIGOperator {
                         .collect(Collectors.toList()));
         mcpConfig.setMcpServerConfig(serverConfig);
 
-        mcpConfig.setProtocol(McpProtocolType.fromString(resp.getProtocol()));
+        mcpConfig.setProtocol(
+                protocolCompatible
+                        ? McpProtocolType.DUAL_HTTP
+                        : McpProtocolType.fromString(resp.getProtocol()));
         mcpConfig.setFromType(
-                StrUtil.equalsIgnoreCase(resp.getProtocol(), "HTTP")
+                !protocolCompatible && StrUtil.equalsIgnoreCase(resp.getProtocol(), "HTTP")
                         ? McpFromType.HTTP_TO_MCP
                         : McpFromType.NATIVE_MCP);
 

--- a/himarket-web/himarket-admin/src/components/api-product/ApiProductLinkApi.tsx
+++ b/himarket-web/himarket-admin/src/components/api-product/ApiProductLinkApi.tsx
@@ -10,7 +10,7 @@ import {
   ReloadOutlined,
 } from '@ant-design/icons';
 import { Card, Button, Modal, message, Space, Dropdown } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useLocale } from '@/contexts/LocaleContext';
 import { apiProductApi, apiDefinitionApi } from '@/lib/api';
@@ -64,25 +64,42 @@ export function ApiProductLinkApi({
 
   // 同步配置加载状态
   const [syncLoading, setSyncLoading] = useState(false);
+  const lastApiDefinitionIdRef = useRef('');
 
   const parsedTools = useParsedMcpTools(apiProduct);
   const connConfig = useMcpConnectionConfig(apiProduct, linkedService, selectedDomainIndex);
 
   // 加载 ApiDefinition 详情（当 sourceType 为 API_DEFINITION 时）
   useEffect(() => {
-    if (linkedService?.sourceType === 'API_DEFINITION' && linkedService.apiDefinitionId) {
-      apiDefinitionApi
-        .getApiDefinition(linkedService.apiDefinitionId)
-        .then((res: unknown) => {
-          const data = (res as { data?: ApiDefinition }).data;
-          if (data) setApiDefinition(data);
-        })
-        .catch(() => {
-          setApiDefinition(null);
-        });
-    } else {
+    if (linkedService?.sourceType !== 'API_DEFINITION' || !linkedService.apiDefinitionId) {
+      lastApiDefinitionIdRef.current = '';
       setApiDefinition(null);
+      return;
     }
+
+    if (lastApiDefinitionIdRef.current === linkedService.apiDefinitionId) {
+      return;
+    }
+    const apiDefinitionId = linkedService.apiDefinitionId;
+    lastApiDefinitionIdRef.current = apiDefinitionId;
+
+    apiDefinitionApi
+      .getApiDefinition(apiDefinitionId)
+      .then((res: unknown) => {
+        if (lastApiDefinitionIdRef.current !== apiDefinitionId) {
+          return;
+        }
+
+        const data = (res as { data?: ApiDefinition }).data;
+        if (data) setApiDefinition(data);
+      })
+      .catch(() => {
+        if (lastApiDefinitionIdRef.current !== apiDefinitionId) {
+          return;
+        }
+
+        setApiDefinition(null);
+      });
   }, [linkedService?.sourceType, linkedService?.apiDefinitionId]);
 
   // 产品切换重置域名索引

--- a/himarket-web/himarket-admin/src/components/api-product/ApiProductSkillPackage.tsx
+++ b/himarket-web/himarket-admin/src/components/api-product/ApiProductSkillPackage.tsx
@@ -391,22 +391,37 @@ export function ApiProductSkillPackage({
   const [nacosSaving, setNacosSaving] = useState(false);
   const [nacosForm] = Form.useForm();
   const [currentNacosName, setCurrentNacosName] = useState<string>('');
+  const lastNacosNameFetchKeyRef = useRef('');
 
   // Fetch nacos name
   useEffect(() => {
-    if (apiProduct.skillConfig?.nacosId) {
-      nacosApi
-        .getNacos({ page: 1, size: 1000 })
-        .then((res: unknown) => {
-          const resObj = res as {
-            data?: { content?: Array<{ nacosId?: string; nacosName?: string }> };
-          };
-          const list = resObj.data?.content || [];
-          const found = list.find((n) => n.nacosId === apiProduct.skillConfig?.nacosId);
-          setCurrentNacosName(found?.nacosName || apiProduct.skillConfig?.nacosId || '');
-        })
-        .catch(() => {});
+    const nacosId = apiProduct.skillConfig?.nacosId;
+    if (!nacosId) {
+      lastNacosNameFetchKeyRef.current = '';
+      setCurrentNacosName('');
+      return;
     }
+
+    if (lastNacosNameFetchKeyRef.current === nacosId) {
+      return;
+    }
+    lastNacosNameFetchKeyRef.current = nacosId;
+
+    nacosApi
+      .getNacos({ page: 1, size: 1000 })
+      .then((res: unknown) => {
+        if (lastNacosNameFetchKeyRef.current !== nacosId) {
+          return;
+        }
+
+        const resObj = res as {
+          data?: { content?: Array<{ nacosId?: string; nacosName?: string }> };
+        };
+        const list = resObj.data?.content || [];
+        const found = list.find((n) => n.nacosId === nacosId);
+        setCurrentNacosName(found?.nacosName || nacosId);
+      })
+      .catch(() => {});
   }, [apiProduct.skillConfig?.nacosId]);
 
   const fetchNacosInstances = async () => {
@@ -537,9 +552,14 @@ export function ApiProductSkillPackage({
 
   // Init sequence ref to cancel stale version fetches (separate from fetchSeqRef)
   const initSeqRef = useRef(0);
+  const lastInitialLoadProductIdRef = useRef('');
 
   // Initial load: versions → file tree, cancel stale runs on remount
   useEffect(() => {
+    if (lastInitialLoadProductIdRef.current === productId) {
+      return;
+    }
+    lastInitialLoadProductIdRef.current = productId;
     const seq = ++initSeqRef.current;
     const init = async () => {
       setLoadingVersions(true);
@@ -703,17 +723,6 @@ export function ApiProductSkillPackage({
       title: t('product.package.forcePublishTitle'),
     });
   };
-
-  useEffect(() => {
-    // Initial file tree load with no version (will be superseded by fetchVersions if versions exist)
-    fetchFileTree(undefined);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [productId]);
-
-  useEffect(() => {
-    fetchVersions();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [productId]);
 
   // Auto-poll version list when any version is in reviewing state
   const hasReviewing = versions.some((item) => item.status === 'reviewing');

--- a/himarket-web/himarket-admin/src/components/api-product/ApiProductWorkerPackage.tsx
+++ b/himarket-web/himarket-admin/src/components/api-product/ApiProductWorkerPackage.tsx
@@ -329,6 +329,8 @@ export function ApiProductWorkerPackage({
   );
   const [treeWidth, setTreeWidth] = useState(240);
   const isDragging = useRef(false);
+  const lastAutoFileTreeKeyRef = useRef('');
+  const lastAutoVersionsProductIdRef = useRef('');
   const [activeTab, setActiveTab] = useState<'overview' | 'file'>('overview');
   const [overviewContent, setOverviewContent] = useState<string | null>(null);
   const [loadingOverview, setLoadingOverview] = useState(false);
@@ -352,6 +354,7 @@ export function ApiProductWorkerPackage({
   };
 
   const fetchFileTree = async (version?: string) => {
+    lastAutoFileTreeKeyRef.current = `${productId}-${version ?? ''}`;
     setLoadingTree(true);
     try {
       const res = (await workerApi.getFiles(productId, version)) as { data?: WorkerFileTreeNode[] };
@@ -456,21 +459,36 @@ export function ApiProductWorkerPackage({
   const [nacosSaving, setNacosSaving] = useState(false);
   const [nacosForm] = Form.useForm();
   const [currentNacosName, setCurrentNacosName] = useState<string>('');
+  const lastNacosNameFetchKeyRef = useRef('');
 
   // Fetch nacos name
   useEffect(() => {
-    if (apiProduct.workerConfig?.nacosId) {
-      nacosApi
-        .getNacos({ page: 1, size: 1000 })
-        .then((res) => {
-          const list =
-            (res as { data?: { content?: Array<{ nacosId: string; nacosName: string }> } }).data
-              ?.content || [];
-          const found = list.find((n) => n.nacosId === apiProduct.workerConfig?.nacosId);
-          setCurrentNacosName(found?.nacosName || apiProduct.workerConfig?.nacosId || '');
-        })
-        .catch(() => {});
+    const nacosId = apiProduct.workerConfig?.nacosId;
+    if (!nacosId) {
+      lastNacosNameFetchKeyRef.current = '';
+      setCurrentNacosName('');
+      return;
     }
+
+    if (lastNacosNameFetchKeyRef.current === nacosId) {
+      return;
+    }
+    lastNacosNameFetchKeyRef.current = nacosId;
+
+    nacosApi
+      .getNacos({ page: 1, size: 1000 })
+      .then((res) => {
+        if (lastNacosNameFetchKeyRef.current !== nacosId) {
+          return;
+        }
+
+        const list =
+          (res as { data?: { content?: Array<{ nacosId: string; nacosName: string }> } }).data
+            ?.content || [];
+        const found = list.find((n) => n.nacosId === nacosId);
+        setCurrentNacosName(found?.nacosName || nacosId);
+      })
+      .catch(() => {});
   }, [apiProduct.workerConfig?.nacosId]);
 
   const fetchNacosInstances = async () => {
@@ -617,11 +635,20 @@ export function ApiProductWorkerPackage({
   };
 
   useEffect(() => {
+    const key = `${productId}-${previewVersion ?? ''}`;
+    if (lastAutoFileTreeKeyRef.current === key) {
+      return;
+    }
+    lastAutoFileTreeKeyRef.current = key;
     fetchFileTree(previewVersion);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [productId, previewVersion]);
 
   useEffect(() => {
+    if (lastAutoVersionsProductIdRef.current === productId) {
+      return;
+    }
+    lastAutoVersionsProductIdRef.current = productId;
     fetchVersions();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [productId]);

--- a/himarket-web/himarket-admin/src/components/portal/PortalDashboard.tsx
+++ b/himarket-web/himarket-admin/src/components/portal/PortalDashboard.tsx
@@ -1,6 +1,6 @@
 import { ReloadOutlined, DashboardOutlined } from '@ant-design/icons';
 import { Card, Spin, Button, Space } from 'antd';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { portalApi } from '@/lib/api';
 import type { Portal } from '@/types';
@@ -14,6 +14,7 @@ export const PortalDashboard: React.FC<PortalDashboardProps> = ({ portal }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [fallback, setFallback] = useState(false);
+  const lastAutoFetchPortalIdRef = useRef('');
 
   const fetchDashboardUrl = async () => {
     if (!portal.portalId) return;
@@ -37,6 +38,11 @@ export const PortalDashboard: React.FC<PortalDashboardProps> = ({ portal }) => {
   };
 
   useEffect(() => {
+    if (!portal.portalId || lastAutoFetchPortalIdRef.current === portal.portalId) {
+      return;
+    }
+
+    lastAutoFetchPortalIdRef.current = portal.portalId;
     fetchDashboardUrl();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [portal.portalId]);

--- a/himarket-web/himarket-admin/src/components/portal/PortalDevelopers.tsx
+++ b/himarket-web/himarket-admin/src/components/portal/PortalDevelopers.tsx
@@ -8,7 +8,7 @@ import {
   ClockCircleOutlined,
 } from '@ant-design/icons';
 import { Button, Space, message, Modal, Tooltip } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { DataTable } from '@/components/common/DataTable';
 import { SubscriptionListModal } from '@/components/subscription/SubscriptionListModal';
@@ -50,6 +50,7 @@ export function PortalDevelopers({ portal }: PortalDevelopersProps) {
   // 订阅列表相关状态
   const [subscriptionModalVisible, setSubscriptionModalVisible] = useState(false);
   const [currentConsumer, setCurrentConsumer] = useState<Consumer | null>(null);
+  const lastAutoFetchKeyRef = useRef('');
 
   const { current: page, pageSize } = pagination;
 
@@ -69,8 +70,14 @@ export function PortalDevelopers({ portal }: PortalDevelopersProps) {
   }, [page, pageSize, portal.portalId]);
 
   useEffect(() => {
+    const key = `${portal.portalId}-${page}-${pageSize}`;
+    if (lastAutoFetchKeyRef.current === key) {
+      return;
+    }
+
+    lastAutoFetchKeyRef.current = key;
     fetchDevelopers();
-  }, [fetchDevelopers]);
+  }, [fetchDevelopers, page, pageSize, portal.portalId]);
 
   const handleUpdateDeveloperStatus = (developerId: string, status: string) => {
     portalApi

--- a/himarket-web/himarket-admin/src/components/portal/PortalOverview.tsx
+++ b/himarket-web/himarket-admin/src/components/portal/PortalOverview.tsx
@@ -6,7 +6,7 @@ import {
   UserOutlined,
 } from '@ant-design/icons';
 import { Button, Card, message } from 'antd';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { StatusIndicator } from '@/components/common';
@@ -70,9 +70,13 @@ export function PortalOverview({ onEdit, portal }: PortalOverviewProps) {
   const { t } = useLocale();
   const [apiCount, setApiCount] = useState(0);
   const [developerCount, setDeveloperCount] = useState(0);
+  const lastAutoFetchPortalIdRef = useRef('');
 
   useEffect(() => {
     if (!portal.portalId) return;
+    if (lastAutoFetchPortalIdRef.current === portal.portalId) return;
+
+    lastAutoFetchPortalIdRef.current = portal.portalId;
 
     portalApi
       .getDeveloperList(portal.portalId, {

--- a/himarket-web/himarket-admin/src/components/portal/PortalPublishedApis.tsx
+++ b/himarket-web/himarket-admin/src/components/portal/PortalPublishedApis.tsx
@@ -1,6 +1,6 @@
 import { DeleteOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
 import { Modal, Button, message, Empty, Tooltip, Table } from 'antd';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { DataTable } from '@/components/common/DataTable';
@@ -29,9 +29,16 @@ export function PortalPublishedApis({ portal }: PortalApiProductsProps) {
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [total, setTotal] = useState(0);
+  const lastAutoFetchKeyRef = useRef('');
 
   useEffect(() => {
     if (portal.portalId) {
+      const key = `${portal.portalId}-${currentPage}-${pageSize}`;
+      if (lastAutoFetchKeyRef.current === key) {
+        return;
+      }
+
+      lastAutoFetchKeyRef.current = key;
       fetchApiProducts();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/himarket-web/himarket-admin/src/components/subscription/SubscriptionListModal.tsx
+++ b/himarket-web/himarket-admin/src/components/subscription/SubscriptionListModal.tsx
@@ -22,6 +22,67 @@ interface SubscriptionListModalProps {
   onCancel: () => void;
 }
 
+type ConsumerSubscriptionsResponse = Awaited<ReturnType<typeof portalApi.getConsumerSubscriptions>>;
+
+interface SubscriptionRefreshResult {
+  allRes: ConsumerSubscriptionsResponse;
+  approvedRes: ConsumerSubscriptionsResponse;
+  pendingRes: ConsumerSubscriptionsResponse;
+}
+
+interface SubscriptionRefreshParams {
+  consumerId: string;
+  page: number;
+  productName?: string;
+  size: number;
+}
+
+const subscriptionRefreshRequests = new Map<string, Promise<SubscriptionRefreshResult>>();
+
+function getSubscriptionRefreshKey({
+  consumerId,
+  page,
+  productName,
+  size,
+}: SubscriptionRefreshParams) {
+  return JSON.stringify([consumerId, page, size, productName || '']);
+}
+
+function loadSubscriptionRefresh(params: SubscriptionRefreshParams) {
+  const key = getSubscriptionRefreshKey(params);
+  const cachedRequest = subscriptionRefreshRequests.get(key);
+  if (cachedRequest) {
+    return cachedRequest;
+  }
+
+  const baseParams = { page: params.page, size: params.size };
+  const searchParams = params.productName ? { productName: params.productName } : {};
+  const request = Promise.all([
+    portalApi.getConsumerSubscriptions(params.consumerId, { ...baseParams, ...searchParams }),
+    portalApi.getConsumerSubscriptions(params.consumerId, {
+      ...baseParams,
+      status: 'PENDING',
+      ...searchParams,
+    }),
+    portalApi.getConsumerSubscriptions(params.consumerId, {
+      ...baseParams,
+      status: 'APPROVED',
+      ...searchParams,
+    }),
+  ])
+    .then(([allRes, pendingRes, approvedRes]) => ({
+      allRes,
+      approvedRes,
+      pendingRes,
+    }))
+    .finally(() => {
+      subscriptionRefreshRequests.delete(key);
+    });
+
+  subscriptionRefreshRequests.set(key, request);
+  return request;
+}
+
 export function SubscriptionListModal({
   consumerId,
   consumerName,
@@ -100,22 +161,13 @@ export function SubscriptionListModal({
   const refreshAll = () => {
     skipFetchRef.current = true;
     setLoading(true);
-    const baseParams = { page: 1, size: 10 };
-    const searchParams = productNameSearch ? { productName: productNameSearch } : {};
-    Promise.all([
-      portalApi.getConsumerSubscriptions(consumerId, { ...baseParams, ...searchParams }),
-      portalApi.getConsumerSubscriptions(consumerId, {
-        ...baseParams,
-        status: 'PENDING',
-        ...searchParams,
-      }),
-      portalApi.getConsumerSubscriptions(consumerId, {
-        ...baseParams,
-        status: 'APPROVED',
-        ...searchParams,
-      }),
-    ])
-      .then(([allRes, pendingRes, approvedRes]) => {
+    loadSubscriptionRefresh({
+      consumerId,
+      page: 1,
+      productName: productNameSearch,
+      size: pagination.pageSize,
+    })
+      .then(({ allRes, approvedRes, pendingRes }) => {
         setStats({
           all: allRes.data?.totalElements || 0,
           approved: approvedRes.data?.totalElements || 0,

--- a/himarket-web/himarket-admin/src/contexts/LocaleContext.tsx
+++ b/himarket-web/himarket-admin/src/contexts/LocaleContext.tsx
@@ -18,6 +18,7 @@ import {
   type TranslationKey,
 } from '@/i18n';
 import { adminSettingApi, type AdminSettingResult } from '@/lib/api';
+import { ADMIN_AUTH_CHANGED_EVENT, isAuthenticated } from '@/lib/utils';
 
 interface LocaleContextValue {
   locale: Locale;
@@ -30,6 +31,7 @@ interface AdminSettingResponse {
 }
 
 const LocaleContext = createContext<LocaleContextValue | null>(null);
+let remoteLocaleRequest: Promise<Locale | null> | null = null;
 
 function getStoredLocale(): Locale {
   if (typeof window === 'undefined') {
@@ -40,33 +42,64 @@ function getStoredLocale(): Locale {
   return isLocale(storedLocale) ? storedLocale : DEFAULT_LOCALE;
 }
 
+function loadRemoteLocale() {
+  if (remoteLocaleRequest) {
+    return remoteLocaleRequest;
+  }
+
+  remoteLocaleRequest = adminSettingApi
+    .getSetting(ADMIN_LOCALE_SETTING_KEY)
+    .then((res: AdminSettingResponse) => {
+      const nextLocale = res.data?.settingValue;
+      return isLocale(nextLocale) ? nextLocale : null;
+    })
+    .catch(() => null)
+    .finally(() => {
+      remoteLocaleRequest = null;
+    });
+
+  return remoteLocaleRequest;
+}
+
 export function LocaleProvider({ children }: { children: ReactNode }) {
   const [locale, setLocaleState] = useState<Locale>(getStoredLocale);
 
   useEffect(() => {
     let cancelled = false;
 
-    adminSettingApi
-      .getSetting(ADMIN_LOCALE_SETTING_KEY)
-      .then((res: AdminSettingResponse) => {
-        const nextLocale = res.data?.settingValue;
-        if (!cancelled && isLocale(nextLocale)) {
+    const syncRemoteLocale = () => {
+      if (!isAuthenticated()) {
+        return;
+      }
+
+      loadRemoteLocale().then((nextLocale) => {
+        if (cancelled) {
+          return;
+        }
+
+        if (nextLocale) {
           setLocaleState(nextLocale);
           window.localStorage.setItem(ADMIN_LOCALE_STORAGE_KEY, nextLocale);
         }
-      })
-      .catch(() => {
-        // Keep the local/default locale when the cross-device setting cannot be loaded.
       });
+    };
+
+    syncRemoteLocale();
+    window.addEventListener(ADMIN_AUTH_CHANGED_EVENT, syncRemoteLocale);
 
     return () => {
       cancelled = true;
+      window.removeEventListener(ADMIN_AUTH_CHANGED_EVENT, syncRemoteLocale);
     };
   }, []);
 
   const setLocale = useCallback((nextLocale: Locale) => {
     setLocaleState(nextLocale);
     window.localStorage.setItem(ADMIN_LOCALE_STORAGE_KEY, nextLocale);
+    if (!isAuthenticated()) {
+      return;
+    }
+
     adminSettingApi.saveSetting(ADMIN_LOCALE_SETTING_KEY, nextLocale).catch(() => {
       // The global interceptor reports the error; the local preference still applies immediately.
     });

--- a/himarket-web/himarket-admin/src/hooks/useAdminViewMode.ts
+++ b/himarket-web/himarket-admin/src/hooks/useAdminViewMode.ts
@@ -13,6 +13,29 @@ function isViewMode(value?: string): value is ViewMode {
   return value === 'TABLE' || value === 'CARD';
 }
 
+const viewModeRequests = new Map<string, Promise<ViewMode | null>>();
+
+function loadViewMode(settingKey: string) {
+  const cachedRequest = viewModeRequests.get(settingKey);
+  if (cachedRequest) {
+    return cachedRequest;
+  }
+
+  const request = adminSettingApi
+    .getSetting(settingKey)
+    .then((res: AdminSettingResponse) => {
+      const settingValue = res.data?.settingValue;
+      return isViewMode(settingValue) ? settingValue : null;
+    })
+    .catch(() => null)
+    .finally(() => {
+      viewModeRequests.delete(settingKey);
+    });
+
+  viewModeRequests.set(settingKey, request);
+  return request;
+}
+
 export function useAdminViewMode(settingKey: string) {
   const [viewMode, setViewModeState] = useState<ViewMode>('TABLE');
   const [loading, setLoading] = useState(true);
@@ -21,16 +44,11 @@ export function useAdminViewMode(settingKey: string) {
     let cancelled = false;
     setLoading(true);
 
-    adminSettingApi
-      .getSetting(settingKey)
-      .then((res: AdminSettingResponse) => {
-        const settingValue = res.data?.settingValue;
-        if (!cancelled && isViewMode(settingValue)) {
-          setViewModeState(settingValue);
+    loadViewMode(settingKey)
+      .then((nextViewMode) => {
+        if (!cancelled && nextViewMode) {
+          setViewModeState(nextViewMode);
         }
-      })
-      .catch(() => {
-        // Keep the default view mode when the setting cannot be loaded.
       })
       .finally(() => {
         if (!cancelled) {

--- a/himarket-web/himarket-admin/src/lib/utils.ts
+++ b/himarket-web/himarket-admin/src/lib/utils.ts
@@ -9,6 +9,14 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 // Token 相关函数
+export const ADMIN_AUTH_CHANGED_EVENT = 'himarket.admin.auth-changed';
+
+export const notifyAdminAuthChanged = (): void => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(ADMIN_AUTH_CHANGED_EVENT));
+  }
+};
+
 export const getToken = (): string | null => {
   return localStorage.getItem('access_token');
 };

--- a/himarket-web/himarket-admin/src/pages/GatewayConsoles.tsx
+++ b/himarket-web/himarket-admin/src/pages/GatewayConsoles.tsx
@@ -1,6 +1,6 @@
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { Button, message, Modal, Tooltip } from 'antd';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 import { AdminPageHeader } from '@/components/common';
 import { DataTable } from '@/components/common/DataTable';
@@ -31,6 +31,7 @@ export default function Consoles() {
     pageSize: 10,
     total: 0,
   });
+  const lastAutoFetchKeyRef = useRef('');
 
   const fetchGatewaysByType = useCallback(async (gatewayType: GatewayType, page = 1, size = 10) => {
     setLoading(true);
@@ -50,6 +51,11 @@ export default function Consoles() {
   }, []);
 
   useEffect(() => {
+    const key = `${activeTab}-1-10`;
+    if (lastAutoFetchKeyRef.current === key) {
+      return;
+    }
+    lastAutoFetchKeyRef.current = key;
     fetchGatewaysByType(activeTab, 1, 10);
   }, [fetchGatewaysByType, activeTab]);
 

--- a/himarket-web/himarket-admin/src/pages/Login.tsx
+++ b/himarket-web/himarket-admin/src/pages/Login.tsx
@@ -1,11 +1,11 @@
 import { Form, Input, Button, Alert } from 'antd';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { authApi } from '@/lib/api';
+import api, { authApi } from '@/lib/api';
+import { notifyAdminAuthChanged } from '@/lib/utils';
 
 import { AdminBrandMark } from '../components/AdminBrand';
-import api from '../lib/api';
 
 const inputClassName = 'h-[42px] rounded-lg text-sm';
 const buttonClassName = 'h-[42px] w-full rounded-lg text-sm font-medium active:scale-[0.985]';
@@ -15,10 +15,17 @@ const Login: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [isRegister, setIsRegister] = useState<boolean | null>(null); // null 表示正在加载
+  const needInitCheckedRef = useRef(false);
   const navigate = useNavigate();
 
   // 页面加载时检查权限
   useEffect(() => {
+    if (needInitCheckedRef.current) {
+      return;
+    }
+
+    needInitCheckedRef.current = true;
+
     const checkAuth = async () => {
       try {
         const response = await authApi.getNeedInit(); // 替换为你的权限接口
@@ -43,6 +50,7 @@ const Login: React.FC = () => {
       const accessToken = response.data.access_token;
       localStorage.setItem('access_token', accessToken);
       localStorage.setItem('userInfo', JSON.stringify(response.data));
+      notifyAdminAuthChanged();
       navigate('/portals');
     } catch {
       setError('账号或密码错误');

--- a/himarket-web/himarket-admin/src/pages/McpMonitor.tsx
+++ b/himarket-web/himarket-admin/src/pages/McpMonitor.tsx
@@ -119,6 +119,7 @@ const McpMonitor: React.FC = () => {
   const successRateChartInstance = useRef<echarts.ECharts | null>(null);
   const qpsChartInstance = useRef<echarts.ECharts | null>(null);
   const rtChartInstance = useRef<echarts.ECharts | null>(null);
+  const initialQueryStartedRef = useRef(false);
 
   // 初始化ECharts实例
   useEffect(() => {
@@ -142,6 +143,10 @@ const McpMonitor: React.FC = () => {
 
   // 初始化默认值
   useEffect(() => {
+    if (initialQueryStartedRef.current) {
+      return;
+    }
+    initialQueryStartedRef.current = true;
     const [start, end] = getPresetTimeRange('1w');
     form.setFieldsValue({
       interval: 15,

--- a/himarket-web/himarket-admin/src/pages/ModelDashboard.tsx
+++ b/himarket-web/himarket-admin/src/pages/ModelDashboard.tsx
@@ -132,6 +132,7 @@ const ModelDashboard: React.FC = () => {
   const rtChartInstance = useRef<echarts.ECharts | null>(null);
   const ratelimitedChartInstance = useRef<echarts.ECharts | null>(null);
   const cacheChartInstance = useRef<echarts.ECharts | null>(null);
+  const initialQueryStartedRef = useRef(false);
 
   // 初始化ECharts实例
   useEffect(() => {
@@ -167,6 +168,10 @@ const ModelDashboard: React.FC = () => {
 
   // 初始化默认值
   useEffect(() => {
+    if (initialQueryStartedRef.current) {
+      return;
+    }
+    initialQueryStartedRef.current = true;
     const [start, end] = getPresetTimeRange('1w');
     form.setFieldsValue({
       interval: 15,

--- a/himarket-web/himarket-admin/src/pages/NacosConsoles.tsx
+++ b/himarket-web/himarket-admin/src/pages/NacosConsoles.tsx
@@ -1,7 +1,7 @@
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { Button, Modal, Form, Input, message, Select, Tooltip } from 'antd';
 import dayjs from 'dayjs';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 import { AdminPageHeader } from '@/components/common';
 import { DataTable } from '@/components/common/DataTable';
@@ -47,6 +47,7 @@ export default function NacosConsoles() {
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [total, setTotal] = useState(0);
+  const lastAutoFetchKeyRef = useRef('');
 
   const fetchNacosInstances = useCallback(async () => {
     setLoading(true);
@@ -65,8 +66,13 @@ export default function NacosConsoles() {
   }, [currentPage, pageSize]);
 
   useEffect(() => {
+    const key = `${currentPage}-${pageSize}`;
+    if (lastAutoFetchKeyRef.current === key) {
+      return;
+    }
+    lastAutoFetchKeyRef.current = key;
     fetchNacosInstances();
-  }, [fetchNacosInstances]);
+  }, [fetchNacosInstances, currentPage, pageSize]);
 
   const handlePageChange = (page: number, size?: number) => {
     setCurrentPage(page);

--- a/himarket-web/himarket-admin/src/pages/PortalDetail.tsx
+++ b/himarket-web/himarket-admin/src/pages/PortalDetail.tsx
@@ -7,7 +7,7 @@ import {
   MenuUnfoldOutlined,
 } from '@ant-design/icons';
 import { Button, Spin, Modal, message } from 'antd';
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { AdminDetailSidebar } from '@/components/common';
@@ -35,6 +35,7 @@ export default function PortalDetail() {
   const [loading, setLoading] = useState(true); // 初始状态为 loading
   const [error, setError] = useState<string | null>(null);
   const [editModalVisible, setEditModalVisible] = useState(false);
+  const lastAutoFetchPortalIdRef = useRef('');
   const menuItems = useMemo(
     () => [
       {
@@ -99,8 +100,13 @@ export default function PortalDetail() {
   }, [portalId, t]);
 
   useEffect(() => {
+    if (!portalId || lastAutoFetchPortalIdRef.current === portalId) {
+      return;
+    }
+
+    lastAutoFetchPortalIdRef.current = portalId;
     fetchPortalData();
-  }, [fetchPortalData]);
+  }, [fetchPortalData, portalId]);
 
   const handleBackToPortals = () => {
     navigate('/portals');

--- a/himarket-web/himarket-admin/src/pages/Portals.tsx
+++ b/himarket-web/himarket-admin/src/pages/Portals.tsx
@@ -12,7 +12,7 @@ import {
   Skeleton,
   Empty,
 } from 'antd';
-import { useState, useCallback, memo, useEffect } from 'react';
+import { useState, useCallback, memo, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { AdminPageHeader, StatusIndicator } from '@/components/common';
@@ -210,6 +210,7 @@ export default function Portals() {
     pageSize: 12,
     total: 0,
   });
+  const lastAutoFetchKeyRef = useRef('');
 
   const fetchPortals = useCallback(
     (page = 1, size = 12) => {
@@ -247,6 +248,12 @@ export default function Portals() {
   );
 
   useEffect(() => {
+    const key = '1-12';
+    if (lastAutoFetchKeyRef.current === key) {
+      return;
+    }
+
+    lastAutoFetchKeyRef.current = key;
     setError(null);
     fetchPortals(1, 12);
   }, [fetchPortals]);

--- a/himarket-web/himarket-admin/src/pages/ProductCategoryDetail.tsx
+++ b/himarket-web/himarket-admin/src/pages/ProductCategoryDetail.tsx
@@ -18,7 +18,7 @@ import {
   Checkbox,
   Pagination,
 } from 'antd';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { DataTable } from '@/components/common/DataTable';
@@ -183,6 +183,7 @@ export default function ProductCategoryDetail() {
   const { categoryId } = useParams<{ categoryId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
+  const lastAutoFetchKeyRef = useRef('');
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
   const { viewMode } = useAdminViewMode(API_PRODUCTS_VIEW_MODE_SETTING_KEY);
 
@@ -241,10 +242,17 @@ export default function ProductCategoryDetail() {
   );
 
   useEffect(() => {
-    if (categoryId) {
-      fetchCategoryDetail();
-      fetchCategoryProducts();
+    if (!categoryId) {
+      return;
     }
+
+    const key = `${categoryId}-1-10`;
+    if (lastAutoFetchKeyRef.current === key) {
+      return;
+    }
+    lastAutoFetchKeyRef.current = key;
+    fetchCategoryDetail();
+    fetchCategoryProducts();
   }, [categoryId, fetchCategoryDetail, fetchCategoryProducts]);
 
   // 渲染类别图标

--- a/himarket-web/himarket-admin/src/pages/ProductTypePage.tsx
+++ b/himarket-web/himarket-admin/src/pages/ProductTypePage.tsx
@@ -67,6 +67,7 @@ const ProductTypePage: React.FC<ProductTypePageProps> = ({ productType }) => {
   const [importModalVisible, setImportModalVisible] = useState(false);
   const [importSource, setImportSource] = useState<StandardImportSource | null>(null);
   const [mcpImportOpen, setMcpImportOpen] = useState(false);
+  const lastDefaultNacosFetchKeyRef = useRef('');
 
   const showNacosImport = productType === 'AGENT_SKILL' || productType === 'WORKER';
   const showImportMenu = productType !== 'AGENT_SKILL' && productType !== 'WORKER';
@@ -79,16 +80,25 @@ const ProductTypePage: React.FC<ProductTypePageProps> = ({ productType }) => {
 
   // Fetch default Nacos instance for import feature
   useEffect(() => {
-    if (showNacosImport) {
-      nacosApi
-        .getDefaultNacos()
-        .then((res: unknown) => {
-          setDefaultNacos((res as { data: NacosInstance | null }).data ?? null);
-        })
-        .catch(() => {
-          setDefaultNacos(null);
-        });
+    if (!showNacosImport) {
+      lastDefaultNacosFetchKeyRef.current = '';
+      setDefaultNacos(null);
+      return;
     }
+
+    if (lastDefaultNacosFetchKeyRef.current === productType) {
+      return;
+    }
+    lastDefaultNacosFetchKeyRef.current = productType;
+
+    nacosApi
+      .getDefaultNacos()
+      .then((res: unknown) => {
+        setDefaultNacos((res as { data: NacosInstance | null }).data ?? null);
+      })
+      .catch(() => {
+        setDefaultNacos(null);
+      });
   }, [productType, showNacosImport]);
 
   const handleImportFromNacos = async () => {

--- a/himarket-web/himarket-admin/src/pages/SandboxConsoles.tsx
+++ b/himarket-web/himarket-admin/src/pages/SandboxConsoles.tsx
@@ -11,7 +11,7 @@ import {
   SyncOutlined,
 } from '@ant-design/icons';
 import { Button, message, Modal, Tabs, Form, Input, Steps, Space, Tooltip } from 'antd';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 import { AdminPageHeader } from '@/components/common';
 import { DataTable } from '@/components/common/DataTable';
@@ -55,6 +55,7 @@ export default function SandboxConsoles() {
   const [importStep, setImportStep] = useState(0);
   const [submitting, setSubmitting] = useState(false);
   const [checkingId, setCheckingId] = useState<string | null>(null);
+  const lastAutoFetchKeyRef = useRef('');
 
   const isAgentRuntime = activeTab === 'AGENT_RUNTIME';
 
@@ -79,6 +80,11 @@ export default function SandboxConsoles() {
   }, []);
 
   useEffect(() => {
+    const key = `${activeTab}-1-10`;
+    if (lastAutoFetchKeyRef.current === key) {
+      return;
+    }
+    lastAutoFetchKeyRef.current = key;
     fetchList(activeTab);
   }, [fetchList, activeTab]);
 

--- a/himarket-web/himarket-frontend/src/pages/AgentDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/AgentDetail.tsx
@@ -224,7 +224,7 @@ function AgentDetail() {
         items={[
           {
             children: data?.document ? (
-              <div className="min-h-[420px]">
+              <div className="scrollbar-thin-soft max-h-[720px] min-h-[420px] overflow-y-auto pr-2">
                 <MarkdownRender content={data.document} />
               </div>
             ) : (

--- a/himarket-web/himarket-frontend/src/pages/ApiDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/ApiDetail.tsx
@@ -180,7 +180,7 @@ function ApiDetailPage() {
         items={[
           {
             children: apiData.document ? (
-              <div className="min-h-[420px]">
+              <div className="scrollbar-thin-soft max-h-[720px] min-h-[420px] overflow-y-auto pr-2">
                 <MarkdownRender content={apiData.document} />
               </div>
             ) : (

--- a/himarket-web/himarket-frontend/src/pages/ModelDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/ModelDetail.tsx
@@ -271,7 +271,7 @@ function ModelDetail() {
         items={[
           {
             children: data?.document ? (
-              <div className="min-h-[420px]">
+              <div className="scrollbar-thin-soft max-h-[720px] min-h-[420px] overflow-y-auto pr-2">
                 <MarkdownRender content={data.document} />
               </div>
             ) : (


### PR DESCRIPTION
## 📝 Description

- Restore the admin login flow by preventing admin preference requests from running before an access token exists.
- Sync admin locale preferences after successful login so authenticated settings still work normally.
- Keep admin page initialization stable after login across related admin views.
- Preserve AI Gateway proxy MCP hosting configuration when importing MCP server metadata.
- Add bounded scrolling for long product documents in developer portal detail pages.

## 🔗 Related Issues

## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests pass locally

Verified with:

- `make compile`
- `himarket-web/himarket-admin`: `tsc --noEmit`
- `himarket-web/himarket-admin`: `eslint .`
- `himarket-web/himarket-frontend`: `tsc -b`
- `himarket-web/himarket-frontend`: `eslint .`
- `git diff --check`

## 📋 Checklist

- [x] Code quality checks passed
- [x] Code is self-reviewed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

## 📊 Test Coverage

No new automated tests were added. The change was verified with scoped frontend checks, backend compile, and manual admin login-flow validation.

## 📚 Additional Notes

`./scripts/code-check.sh` was not run end-to-end because the local hook/tooling environment is missing `npx`; scoped admin, frontend, backend, and diff checks passed locally.