### PR TITLE
fix(admin): display API definition links in MCP product overview

### DIFF
--- a/himarket-web/himarket-admin/src/components/api-product/ApiProductOverview.tsx
+++ b/himarket-web/himarket-admin/src/components/api-product/ApiProductOverview.tsx
@@ -14,8 +14,7 @@ import { useLocale } from '@/contexts/LocaleContext';
 import { apiProductApi } from '@/lib/api';
 import { getProductCategories } from '@/lib/productCategoryApi';
 import { getServiceName, formatDateTime, copyToClipboard } from '@/lib/utils';
-import type { ApiProduct } from '@/types/api-product';
-import type { LinkedService } from '@/types/api-product';
+import type { ApiProduct, LinkedService } from '@/types/api-product';
 import type { ProductCategory } from '@/types/product-category';
 
 import type { ReactNode } from 'react';
@@ -55,6 +54,19 @@ function renderProductStatus(status: ApiProduct['status'], t: ReturnType<typeof 
     );
   }
   return <StatusIndicator tone="success">{t('product.overview.statusPublished')}</StatusIndicator>;
+}
+
+function getLinkedServiceOverviewName(apiProduct: ApiProduct, linkedService: LinkedService | null) {
+  const serviceName = getServiceName(linkedService);
+  if (serviceName) {
+    return serviceName;
+  }
+
+  if (linkedService?.sourceType === 'API_DEFINITION' || linkedService?.sourceType === 'CUSTOM') {
+    return apiProduct.mcpConfig?.mcpServerName || apiProduct.name;
+  }
+
+  return null;
 }
 
 function InfoItem({
@@ -349,7 +361,10 @@ export function ApiProductOverview({ apiProduct, linkedService, onEdit }: ApiPro
                 state: location.state,
               });
             }}
-            value={getServiceName(linkedService) || t('product.overview.unlinked')}
+            value={
+              getLinkedServiceOverviewName(apiProduct, linkedService) ||
+              t('product.overview.unlinked')
+            }
           />
           <MetricCard
             icon={<TeamOutlined />}


### PR DESCRIPTION
## 📝 Description

- Fix MCP product overview to show linked API definition or custom MCP server names
- Keep fallback behavior for unlinked MCP products

## ✅ Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## 🧪 Testing

- [x] npm run type-check
- [x] npm run format:check
- [ ] npm run lint

Lint has existing unrelated issues in vite.config files.

## 📋 Checklist

- [x] Code has been formatted
- [x] Code is self-reviewed
- [x] No breaking changes