### PR TITLE
fix: normalize product detail gateway config

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/AIGWOperator.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/AIGWOperator.java
@@ -42,6 +42,7 @@ import com.alibaba.himarket.service.gateway.client.APIGClient;
 import com.alibaba.himarket.support.consumer.APIGAuthConfig;
 import com.alibaba.himarket.support.consumer.ConsumerAuthConfig;
 import com.alibaba.himarket.support.enums.*;
+import com.alibaba.himarket.support.mcp.OpenAPIToolsConfigConverter;
 import com.alibaba.himarket.support.product.APIGRefConfig;
 import com.alibaba.himarket.utils.JsonUtil;
 import com.aliyun.sdk.gateway.pop.exception.PopClientException;
@@ -171,7 +172,8 @@ public class AIGWOperator extends APIGOperator {
         // tools
         String tools = resp.getMcpServerConfig();
         if (StrUtil.isNotBlank(tools)) {
-            mcpConfig.setTools(Base64.isBase64(tools) ? Base64.decodeStr(tools) : tools);
+            String decodedTools = Base64.isBase64(tools) ? Base64.decodeStr(tools) : tools;
+            mcpConfig.setTools(OpenAPIToolsConfigConverter.convertRawConfigToJson(decodedTools));
         }
 
         return JsonUtil.toJson(mcpConfig);

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/HigressOperator.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/gateway/HigressOperator.java
@@ -52,6 +52,7 @@ import com.alibaba.himarket.support.enums.McpProtocolType;
 import com.alibaba.himarket.support.enums.ProductType;
 import com.alibaba.himarket.support.gateway.GatewayConfig;
 import com.alibaba.himarket.support.gateway.HigressConfig;
+import com.alibaba.himarket.support.mcp.OpenAPIToolsConfigConverter;
 import com.alibaba.himarket.support.product.HigressRefConfig;
 import com.alibaba.himarket.utils.JsonUtil;
 import com.aliyun.sdk.service.apig20240327.models.HttpApiApiInfo;
@@ -216,7 +217,9 @@ public class HigressOperator extends GatewayOperator<HigressClient> {
         m.setMcpServerConfig(c);
 
         // tools
-        m.setTools(higressMCPConfig.getRawConfigurations());
+        m.setTools(
+                OpenAPIToolsConfigConverter.convertRawConfigToJson(
+                        higressMCPConfig.getRawConfigurations()));
 
         m.setFromType(
                 "open_api".equalsIgnoreCase(higressMCPConfig.getType())

--- a/himarket-server/src/main/java/com/alibaba/himarket/support/mcp/OpenAPIToolsConfigConverter.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/support/mcp/OpenAPIToolsConfigConverter.java
@@ -24,13 +24,18 @@ import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.map.MapUtil;
 import cn.hutool.core.util.StrUtil;
 import com.alibaba.himarket.support.api.spec.OpenAPIToolsConfig;
+import com.alibaba.himarket.utils.JsonUtil;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpTool;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.modelcontextprotocol.spec.McpSchema;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 /**
  * Converter that produces {@link OpenAPIToolsConfig} from Nacos or MCP SDK types.
@@ -88,6 +93,56 @@ public final class OpenAPIToolsConfigConverter {
                         .filter(Objects::nonNull)
                         .collect(Collectors.toList()));
         return config;
+    }
+
+    /**
+     * Convert raw gateway tools config to JSON.
+     *
+     * @param raw raw tools config in JSON or YAML
+     * @return JSON config, or null when the input cannot be parsed
+     */
+    public static String convertRawConfigToJson(String raw) {
+        OpenAPIToolsConfig config = convertFromRawConfig(raw);
+        return config == null ? null : JsonUtil.toJson(config);
+    }
+
+    /**
+     * Convert raw gateway tools config.
+     *
+     * @param raw raw tools config in JSON or YAML
+     * @return tools config, or null when the input cannot be parsed
+     */
+    public static OpenAPIToolsConfig convertFromRawConfig(String raw) {
+        if (StrUtil.isBlank(raw)) {
+            return null;
+        }
+
+        String trimmed = raw.trim();
+        if (trimmed.startsWith("{")) {
+            Map<String, Object> parsed = JsonUtil.parse(trimmed, new TypeReference<>() {});
+            parsed.putIfAbsent("format", "OPEN_API");
+            return JsonUtil.convert(parsed, OpenAPIToolsConfig.class);
+        }
+
+        try {
+            Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+            Object parsed = yaml.load(raw);
+            if (parsed instanceof Map<?, ?> rawMap) {
+                Map<String, Object> config = new LinkedHashMap<>();
+                rawMap.forEach(
+                        (key, value) -> {
+                            if (key != null) {
+                                config.put(String.valueOf(key), value);
+                            }
+                        });
+                config.putIfAbsent("format", "OPEN_API");
+                return JsonUtil.convert(config, OpenAPIToolsConfig.class);
+            }
+            return parsed == null ? null : JsonUtil.convert(parsed, OpenAPIToolsConfig.class);
+        } catch (Exception e) {
+            log.warn("Failed to parse MCP tools config; tools will be omitted: {}", e.getMessage());
+            return null;
+        }
     }
 
     private static OpenAPIToolsConfig.OpenAPITool convertNacosTool(McpTool mcpTool) {

--- a/himarket-server/src/test/java/com/alibaba/himarket/support/mcp/OpenAPIToolsConfigConverterTest.java
+++ b/himarket-server/src/test/java/com/alibaba/himarket/support/mcp/OpenAPIToolsConfigConverterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.alibaba.himarket.support.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.alibaba.himarket.utils.JsonUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+class OpenAPIToolsConfigConverterTest {
+
+    @Test
+    void shouldDeserializeRawGatewayConfigWithoutUnknownCredentialFields() {
+        String raw =
+                String.join(
+                        "\n",
+                        "server:",
+                        "  name: time",
+                        "  type: mcp-proxy",
+                        "  transport: sse",
+                        "  mcpServerURL: http://example.com/sse",
+                        "  defaultUpstreamSecurity:",
+                        "    id: ApiKeyAuth",
+                        "  securitySchemes:",
+                        "    - id: ApiKeyAuth",
+                        "      type: apiKey",
+                        "      in: header",
+                        "      name: Authorization",
+                        "      defaultCredential: Bearer sk-test-secret",
+                        "tools:",
+                        "  - name: get_current_time",
+                        "    description: Get current time",
+                        "    args:",
+                        "      - name: timezone",
+                        "        description: IANA timezone name",
+                        "        type: string",
+                        "        required: true",
+                        "        default: Asia/Shanghai",
+                        "    requestTemplate:",
+                        "      url: http://example.com",
+                        "      security:",
+                        "        id: ApiKeyAuth",
+                        "    responseTemplate: {}");
+
+        String result = OpenAPIToolsConfigConverter.convertRawConfigToJson(raw);
+
+        assertNotNull(result);
+        assertFalse(result.contains("defaultCredential"));
+        assertFalse(result.contains("Authorization"));
+        assertFalse(result.contains("Bearer"));
+
+        JsonNode root = JsonUtil.readTree(result);
+        assertEquals("time", root.path("server").path("name").asText());
+        JsonNode tool = root.path("tools").get(0);
+        assertEquals("get_current_time", tool.path("name").asText());
+        assertEquals("Get current time", tool.path("description").asText());
+
+        JsonNode arg = tool.path("args").get(0);
+        assertEquals("timezone", arg.path("name").asText());
+        assertEquals("string", arg.path("type").asText());
+        assertTrue(arg.path("required").asBoolean());
+    }
+}

--- a/himarket-web/himarket-frontend/src/components/ProductHeader.tsx
+++ b/himarket-web/himarket-frontend/src/components/ProductHeader.tsx
@@ -62,11 +62,13 @@ interface ProductHeaderProps {
 
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
 
+const hasIconValue = (icon?: IProductIcon): icon is IProductIcon => Boolean(icon?.value?.trim());
+
 // 处理产品图标的函数
 const getIconUrl = (icon?: IProductIcon, defaultIcon?: string): string => {
   const fallback = defaultIcon || '/logo.svg';
 
-  if (!icon) {
+  if (!hasIconValue(icon)) {
     return fallback;
   }
 
@@ -334,7 +336,7 @@ export const ProductHeader = forwardRef<ProductHeaderHandle, ProductHeaderProps>
           <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
               <div className="flex min-w-0 items-start gap-4">
-                {(!icon || imageLoadFailed) &&
+                {(!hasIconValue(icon) || imageLoadFailed) &&
                 (productType === 'REST_API' ||
                   productType === 'AGENT_API' ||
                   productType === 'MODEL_API') ? (

--- a/himarket-web/himarket-frontend/src/locales/en-US/agentDetail.json
+++ b/himarket-web/himarket-frontend/src/locales/en-US/agentDetail.json
@@ -41,7 +41,7 @@
     "unknown": "Unknown"
   },
   "route": {
-    "title": "API configuration",
+    "title": "Route configuration",
     "unknown": "Unknown route",
     "domain": "Domain",
     "selectDomain": "Select domain",

--- a/himarket-web/himarket-frontend/src/locales/zh-CN/agentDetail.json
+++ b/himarket-web/himarket-frontend/src/locales/zh-CN/agentDetail.json
@@ -41,7 +41,7 @@
     "unknown": "未知"
   },
   "route": {
-    "title": "API 配置",
+    "title": "路由配置",
     "unknown": "未知路由",
     "domain": "域名",
     "selectDomain": "选择域名",

--- a/himarket-web/himarket-frontend/src/pages/AgentDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/AgentDetail.tsx
@@ -441,201 +441,192 @@ function AgentDetail() {
                 )}
 
                 {agentRoutes.length > 0 && (
-                  <div className="overflow-hidden rounded-[12px] border border-[#DDE5F0] bg-white">
-                    <div className="border-b border-[#E8EDF5] px-4 py-3 text-sm font-semibold text-gray-950">
+                  <div>
+                    <div className="mb-4 text-sm font-semibold text-gray-900">
                       {t('route.title')}
                     </div>
 
-                    <div className="p-4">
-                      {agentDomainOptions.length > 0 && (
-                        <div className="mb-4">
-                          <div className="flex overflow-hidden rounded-[10px] border border-[#DDE5F0] bg-white">
-                            <span className="flex flex-shrink-0 items-center whitespace-nowrap border-r border-[#E8EDF5] bg-[#FBFCFE] px-3 py-2 text-xs font-medium text-gray-600">
-                              {t('route.domain')}:
-                            </span>
-                            <div className="flex-1">
-                              <Select
-                                className="w-full"
-                                labelRender={() => (
-                                  <div className="inline-flex max-w-full items-center gap-1.5">
-                                    <span className="min-w-0 truncate font-mono text-xs text-gray-900">
-                                      {selectedAgentDomain?.label || t('route.selectDomain')}
-                                    </span>
-                                    <Button
-                                      aria-label={t('route.copyDomain')}
-                                      disabled={!selectedAgentDomain?.label}
-                                      icon={<CopyOutlined />}
-                                      onClick={(event) => {
-                                        event.stopPropagation();
-                                        handleCopySelectedAgentDomain();
-                                      }}
-                                      onMouseDown={(event) => event.stopPropagation()}
-                                      size="small"
-                                      title={t('route.copyDomain')}
-                                      type="text"
-                                    />
-                                  </div>
-                                )}
-                                onChange={setSelectedAgentDomainIndex}
-                                optionLabelProp="label"
-                                placeholder={t('route.selectDomain')}
-                                size="middle"
-                                value={selectedAgentDomainIndex}
-                                variant="borderless"
-                              >
-                                {agentDomainOptions.map((option) => (
-                                  <Select.Option
-                                    key={option.value}
-                                    label={option.label}
-                                    value={option.value}
-                                  >
-                                    <span className="font-mono text-sm text-gray-900">
-                                      {option.label}
-                                    </span>
-                                  </Select.Option>
-                                ))}
-                              </Select>
-                            </div>
-                          </div>
-                        </div>
-                      )}
-
-                      <div className="overflow-hidden rounded-[12px] border border-[#DDE5F0] bg-white">
-                        <Collapse expandIconPosition="end" ghost>
-                          {agentRoutes.map((route, index) => (
-                            <Panel
-                              className={
-                                index < agentRoutes.length - 1 ? 'border-b border-[#EEF2F7]' : ''
-                              }
-                              header={
-                                <div className="flex items-center justify-between py-2">
-                                  <div className="flex-1">
-                                    <div className="mb-1 font-mono text-sm font-medium text-blue-600">
-                                      {getRouteDisplayText(route, selectedAgentDomainIndex)}
-                                      {route.builtin && (
-                                        <span className="ml-2 rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700">
-                                          {t('route.default')}
-                                        </span>
-                                      )}
-                                    </div>
-                                    <div className="text-xs text-gray-500">
-                                      {t('route.method')}:{' '}
-                                      <span className="font-medium text-gray-700">
-                                        {getMethodsText(route)}
-                                      </span>
-                                    </div>
-                                  </div>
+                    {agentDomainOptions.length > 0 && (
+                      <div className="mb-4">
+                        <div className="flex overflow-hidden rounded-[10px] border border-[#DDE5F0] bg-white">
+                          <span className="flex flex-shrink-0 items-center whitespace-nowrap border-r border-[#E8EDF5] bg-[#FBFCFE] px-3 py-2 text-xs font-medium text-gray-600">
+                            {t('route.domain')}:
+                          </span>
+                          <div className="flex-1">
+                            <Select
+                              className="w-full"
+                              labelRender={() => (
+                                <div className="inline-flex max-w-full items-center gap-1.5">
+                                  <span className="min-w-0 truncate font-mono text-xs text-gray-900">
+                                    {selectedAgentDomain?.label || t('route.selectDomain')}
+                                  </span>
                                   <Button
-                                    className="ml-2"
+                                    aria-label={t('route.copyDomain')}
+                                    disabled={!selectedAgentDomain?.label}
                                     icon={<CopyOutlined />}
-                                    onClick={async (e) => {
-                                      e.stopPropagation();
-                                      if (
-                                        allUniqueDomains.length > 0 &&
-                                        allUniqueDomains.length > selectedAgentDomainIndex
-                                      ) {
-                                        const selectedDomain =
-                                          allUniqueDomains[selectedAgentDomainIndex];
-                                        if (selectedDomain) {
-                                          const fullUrl = getRouteEndpoint(
-                                            route,
-                                            selectedAgentDomainIndex,
-                                          );
-                                          copyToClipboard(fullUrl).then(() => {
-                                            message.success(t('message.linkCopied'));
-                                          });
-                                        }
-                                      } else if (route.domains && route.domains.length > 0) {
-                                        const domain = route.domains[0];
-                                        if (domain) {
-                                          const path = route.match?.path?.value || '/';
-                                          const formattedDomain = formatDomainWithPort(
-                                            domain.domain,
-                                            domain.port,
-                                            domain.protocol,
-                                          );
-                                          const fullUrl = `${domain.protocol.toLowerCase()}://${formattedDomain}${path}`;
-                                          copyToClipboard(fullUrl).then(() => {
-                                            message.success(t('message.linkCopied'));
-                                          });
-                                        }
-                                      }
+                                    onClick={(event) => {
+                                      event.stopPropagation();
+                                      handleCopySelectedAgentDomain();
                                     }}
+                                    onMouseDown={(event) => event.stopPropagation()}
                                     size="small"
+                                    title={t('route.copyDomain')}
                                     type="text"
                                   />
                                 </div>
-                              }
-                              key={index}
+                              )}
+                              onChange={setSelectedAgentDomainIndex}
+                              optionLabelProp="label"
+                              placeholder={t('route.selectDomain')}
+                              size="middle"
+                              value={selectedAgentDomainIndex}
+                              variant="borderless"
                             >
-                              <div className="space-y-4 pb-4 pl-4">
-                                {/* 匹配规则 */}
-                                <div className="grid grid-cols-2 gap-4">
-                                  <div>
-                                    <div className="mb-1 text-xs text-gray-500">
-                                      {t('route.path')}:
-                                    </div>
-                                    <div className="rounded-lg bg-gray-50 px-3 py-2 font-mono text-sm">
-                                      {getMatchTypePrefix(route.match?.path?.type)}{' '}
-                                      {route.match?.path?.value}
-                                    </div>
+                              {agentDomainOptions.map((option) => (
+                                <Select.Option
+                                  key={option.value}
+                                  label={option.label}
+                                  value={option.value}
+                                >
+                                  <span className="font-mono text-xs text-gray-900">
+                                    {option.label}
+                                  </span>
+                                </Select.Option>
+                              ))}
+                            </Select>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="overflow-hidden rounded-[12px] border border-[#DDE5F0] bg-white">
+                      <Collapse expandIconPosition="end" ghost>
+                        {agentRoutes.map((route, index) => (
+                          <Panel
+                            className={
+                              index < agentRoutes.length - 1 ? 'border-b border-gray-100' : ''
+                            }
+                            header={
+                              <div className="flex items-center justify-between py-2">
+                                <div className="flex-1">
+                                  <div className="mb-1 font-mono text-sm font-medium text-blue-600">
+                                    {getRouteDisplayText(route, selectedAgentDomainIndex)}
+                                    {route.builtin && (
+                                      <span className="ml-2 rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-800">
+                                        {t('route.default')}
+                                      </span>
+                                    )}
                                   </div>
-                                  <div>
-                                    <div className="mb-1 text-xs text-gray-500">
-                                      {t('route.method')}:
-                                    </div>
-                                    <div className="rounded-lg bg-gray-50 px-3 py-2 font-mono text-sm">
-                                      {route.match?.methods
-                                        ? route.match.methods.join(', ')
-                                        : 'ANY'}
-                                    </div>
+                                  <div className="text-xs text-gray-500">
+                                    {t('route.method')}:{' '}
+                                    <span className="font-medium text-gray-700">
+                                      {getMethodsText(route)}
+                                    </span>
                                   </div>
                                 </div>
-
-                                {/* 请求头匹配 */}
-                                {route.match?.headers && route.match.headers.length > 0 && (
-                                  <div>
-                                    <div className="mb-2 text-xs text-gray-500">
-                                      {t('route.headerMatch')}:
-                                    </div>
-                                    <div className="space-y-1">
-                                      {route.match.headers.map((header, headerIndex: number) => (
-                                        <div
-                                          className="rounded-lg bg-gray-50 px-3 py-2 font-mono text-sm"
-                                          key={headerIndex}
-                                        >
-                                          {header.name} {getMatchTypePrefix(header.type)}{' '}
-                                          {header.value}
-                                        </div>
-                                      ))}
-                                    </div>
-                                  </div>
-                                )}
-
-                                {/* 查询参数匹配 */}
-                                {route.match?.queryParams && route.match.queryParams.length > 0 && (
-                                  <div>
-                                    <div className="mb-2 text-xs text-gray-500">
-                                      {t('route.queryParamMatch')}:
-                                    </div>
-                                    <div className="space-y-1">
-                                      {route.match.queryParams.map((param, paramIndex: number) => (
-                                        <div
-                                          className="rounded-lg bg-gray-50 px-3 py-2 font-mono text-sm"
-                                          key={paramIndex}
-                                        >
-                                          {param.name} {getMatchTypePrefix(param.type)}{' '}
-                                          {param.value}
-                                        </div>
-                                      ))}
-                                    </div>
-                                  </div>
-                                )}
+                                <Button
+                                  icon={<CopyOutlined />}
+                                  onClick={async (e) => {
+                                    e.stopPropagation();
+                                    if (
+                                      allUniqueDomains.length > 0 &&
+                                      allUniqueDomains.length > selectedAgentDomainIndex
+                                    ) {
+                                      const selectedDomain =
+                                        allUniqueDomains[selectedAgentDomainIndex];
+                                      if (selectedDomain) {
+                                        const fullUrl = getRouteEndpoint(
+                                          route,
+                                          selectedAgentDomainIndex,
+                                        );
+                                        copyToClipboard(fullUrl).then(() => {
+                                          message.success(t('message.linkCopied'));
+                                        });
+                                      }
+                                    } else if (route.domains && route.domains.length > 0) {
+                                      const domain = route.domains[0];
+                                      if (domain) {
+                                        const path = route.match?.path?.value || '/';
+                                        const formattedDomain = formatDomainWithPort(
+                                          domain.domain,
+                                          domain.port,
+                                          domain.protocol,
+                                        );
+                                        const fullUrl = `${domain.protocol.toLowerCase()}://${formattedDomain}${path}`;
+                                        copyToClipboard(fullUrl).then(() => {
+                                          message.success(t('message.linkCopied'));
+                                        });
+                                      }
+                                    }
+                                  }}
+                                  size="small"
+                                  type="text"
+                                />
                               </div>
-                            </Panel>
-                          ))}
-                        </Collapse>
-                      </div>
+                            }
+                            key={index}
+                          >
+                            <div className="space-y-4 pb-4 pl-4">
+                              <div className="grid grid-cols-2 gap-4">
+                                <div>
+                                  <div className="mb-1 text-xs text-gray-500">
+                                    {t('route.path')}:
+                                  </div>
+                                  <div className="rounded-lg bg-gray-50 px-3 py-2 font-mono text-sm">
+                                    {getMatchTypePrefix(route.match?.path?.type)}{' '}
+                                    {route.match?.path?.value}
+                                  </div>
+                                </div>
+                                <div>
+                                  <div className="mb-1 text-xs text-gray-500">
+                                    {t('route.method')}:
+                                  </div>
+                                  <div className="rounded-lg bg-gray-50 px-3 py-2 font-mono text-sm">
+                                    {getMethodsText(route)}
+                                  </div>
+                                </div>
+                              </div>
+
+                              {route.match?.headers && route.match.headers.length > 0 && (
+                                <div>
+                                  <div className="mb-2 text-xs text-gray-500">
+                                    {t('route.headerMatch')}:
+                                  </div>
+                                  <div className="space-y-1">
+                                    {route.match.headers.map((header, headerIndex: number) => (
+                                      <div
+                                        className="rounded-lg bg-gray-50 px-3 py-2 font-mono text-sm"
+                                        key={headerIndex}
+                                      >
+                                        {header.name} {getMatchTypePrefix(header.type)}{' '}
+                                        {header.value}
+                                      </div>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+
+                              {route.match?.queryParams && route.match.queryParams.length > 0 && (
+                                <div>
+                                  <div className="mb-2 text-xs text-gray-500">
+                                    {t('route.queryParamMatch')}:
+                                  </div>
+                                  <div className="space-y-1">
+                                    {route.match.queryParams.map((param, paramIndex: number) => (
+                                      <div
+                                        className="rounded-lg bg-gray-50 px-3 py-2 font-mono text-sm"
+                                        key={paramIndex}
+                                      >
+                                        {param.name} {getMatchTypePrefix(param.type)} {param.value}
+                                      </div>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          </Panel>
+                        ))}
+                      </Collapse>
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Description

- Normalize raw MCP tools config from AI Gateway and Higress before storing product details so sensitive gateway credential fields are not exposed in MCP product details.
- Align Agent detail route configuration wording and layout with the model route configuration style.
- Use fallback product icons when icon metadata exists but has no usable value.

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Frontend type check: /Applications/Codex.app/Contents/Resources/node node_modules/typescript/bin/tsc -b
- [x] Backend targeted test: ./mvnw -pl himarket-server -am -Dtest=OpenAPIToolsConfigConverterTest -Dsurefire.failIfNoSpecifiedTests=false test