### PR TITLE
fix: prevent admin account from being maliciously initialized

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/AdministratorServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/AdministratorServiceImpl.java
@@ -73,6 +73,9 @@ public class AdministratorServiceImpl implements AdministratorService {
 
     @Override
     public AdminResult initAdmin(String username, String password) {
+        if (!needInit()) {
+            throw new BusinessException(ErrorCode.CONFLICT, "Administrator already exists");
+        }
         Administrator admin =
                 Administrator.builder()
                         .adminId(generateAdminId())


### PR DESCRIPTION
## Description

- Prevent admin initialization from proceeding when an admin account already exists.
- Reduces the risk of malicious or repeated admin account initialization.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## Testing

- Ran `./mvnw -q -pl himarket-server -am -DskipTests compile` locally.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] All tests pass locally

## Checklist

- [ ] Code quality checks passed (run `./scripts/code-check.sh`)
- [x] Code is self-reviewed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

## Test Coverage

- No new tests were added; this is a small guard-condition fix.

## Additional Notes

- PR branch is based on current `upstream/main` and contains one commit.
