### PR TITLE
fix: enforce AIRegistry skill exclusive binding

### DIFF
--- a/himarket-server/src/main/java/com/alibaba/himarket/core/skill/SkillZipParser.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/core/skill/SkillZipParser.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.alibaba.himarket.core.skill;
+
+import com.alibaba.himarket.core.exception.BusinessException;
+import com.alibaba.himarket.core.exception.ErrorCode;
+import com.alibaba.himarket.support.common.Strings;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Objects;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import org.yaml.snakeyaml.Yaml;
+
+public final class SkillZipParser {
+
+    private static final String SKILL_MD = "SKILL.md";
+
+    private SkillZipParser() {}
+
+    public static String parseSkillName(byte[] zipBytes) {
+        if (zipBytes == null || zipBytes.length == 0) {
+            throw new BusinessException(ErrorCode.INVALID_PARAMETER, "ZIP file is empty");
+        }
+        String skillMd = null;
+        try (ZipInputStream zis =
+                new ZipInputStream(new ByteArrayInputStream(zipBytes), StandardCharsets.UTF_8)) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                String entryName = entry.getName();
+                if (shouldSkip(entry, entryName)) {
+                    continue;
+                }
+                String baseName = baseName(entryName);
+                if (SKILL_MD.equals(baseName) && skillMd == null) {
+                    skillMd = new String(zis.readAllBytes(), StandardCharsets.UTF_8);
+                }
+            }
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(
+                    ErrorCode.INVALID_PARAMETER, "ZIP parse failed: " + e.getMessage());
+        }
+
+        try {
+            String skillName = parseSkillMdName(skillMd);
+            if (Strings.isNotBlank(skillName)) {
+                return skillName;
+            }
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(
+                    ErrorCode.INVALID_PARAMETER, "ZIP parse failed: " + e.getMessage());
+        }
+        throw new BusinessException(
+                ErrorCode.INVALID_PARAMETER, "Invalid Skill package: skill name is required");
+    }
+
+    private static boolean shouldSkip(ZipEntry entry, String name) {
+        return entry.isDirectory()
+                || name.startsWith("__MACOSX/")
+                || name.endsWith(".DS_Store")
+                || baseName(name).startsWith("._");
+    }
+
+    private static String baseName(String path) {
+        int slash = path.lastIndexOf('/');
+        return slash >= 0 ? path.substring(slash + 1) : path;
+    }
+
+    private static String parseSkillMdName(String content) {
+        if (Strings.isBlank(content)) {
+            return null;
+        }
+        String normalized = content.replace("\r\n", "\n").replace('\r', '\n');
+        String[] lines = normalized.split("\n", -1);
+        int start = firstNonBlankLine(lines);
+        if (start < 0 || !"---".equals(lines[start].trim())) {
+            return null;
+        }
+        StringBuilder frontMatter = new StringBuilder();
+        for (int i = start + 1; i < lines.length; i++) {
+            if ("---".equals(lines[i].trim())) {
+                return parseYamlName(frontMatter.toString());
+            }
+            frontMatter.append(lines[i]).append('\n');
+        }
+        return null;
+    }
+
+    private static int firstNonBlankLine(String[] lines) {
+        for (int i = 0; i < lines.length; i++) {
+            if (Strings.isNotBlank(lines[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static String parseYamlName(String content) {
+        Object parsed = new Yaml().load(content);
+        if (!(parsed instanceof Map<?, ?> map)) {
+            return null;
+        }
+        return Objects.toString(map.get("name"), null);
+    }
+}

--- a/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
+++ b/himarket-server/src/main/java/com/alibaba/himarket/service/impl/SkillServiceImpl.java
@@ -6,6 +6,7 @@ import com.alibaba.himarket.core.exception.ErrorCode;
 import com.alibaba.himarket.core.security.ContextHolder;
 import com.alibaba.himarket.core.skill.FileTreeBuilder;
 import com.alibaba.himarket.core.skill.SkillMdBuilder;
+import com.alibaba.himarket.core.skill.SkillZipParser;
 import com.alibaba.himarket.core.utils.IdGenerator;
 import com.alibaba.himarket.dto.converter.OutputConverter;
 import com.alibaba.himarket.dto.params.skill.CreateSkillDraftParam;
@@ -96,15 +97,32 @@ public class SkillServiceImpl implements SkillService {
                 throw new BusinessException(
                         ErrorCode.INVALID_REQUEST, "AIRegistry skill config not found");
             }
-            String skillName =
+            String parsedSkillName = SkillZipParser.parseSkillName(zipBytes);
+            AiRegistryUploadBinding binding =
+                    resolveAiRegistryUploadBinding(product, config, parsedSkillName);
+
+            String uploadedSkillName =
                     aiRegistrySkillService.uploadFromZip(
                             config.getAiRegistryId(),
                             config.getNamespace(),
                             zipBytes,
                             file.getOriginalFilename(),
                             true);
-            if (Strings.isBlank(config.getSkillName())) {
-                config.setSkillName(skillName);
+            if (!Objects.equals(uploadedSkillName, parsedSkillName)) {
+                log.warn(
+                        "AIRegistry returned unexpected Skill name, productId={},"
+                                + " airegistryId={}, namespace={}, parsedSkillName={},"
+                                + " uploadedSkillName={}",
+                        productId,
+                        config.getAiRegistryId(),
+                        config.getNamespace(),
+                        parsedSkillName,
+                        uploadedSkillName);
+                throw new BusinessException(
+                        ErrorCode.INVALID_REQUEST, "AIRegistry returned unexpected Skill name");
+            }
+            if (binding.updateLocalSkillName()) {
+                config.setSkillName(uploadedSkillName);
                 config.setVersionInfos(null);
                 config.setLatestVersion(null);
             }
@@ -144,6 +162,69 @@ public class SkillServiceImpl implements SkillService {
         return product.getFeature().getSkillConfig();
     }
 
+    private AiRegistryUploadBinding resolveAiRegistryUploadBinding(
+            Product product, SkillConfig config, String skillName) {
+        if (Strings.isBlank(config.getSkillName())) {
+            ensureAiRegistrySkillNameAvailable(product, config, skillName);
+            return new AiRegistryUploadBinding(true);
+        }
+
+        boolean sharedCurrentSkill =
+                findOtherAiRegistrySkillProduct(product, config, config.getSkillName()) != null;
+        if (!sharedCurrentSkill) {
+            if (!Objects.equals(config.getSkillName(), skillName)) {
+                throw new BusinessException(
+                        ErrorCode.CONFLICT,
+                        "Skill package name must match current bound Skill: "
+                                + config.getSkillName());
+            }
+            return new AiRegistryUploadBinding(false);
+        }
+
+        if (Objects.equals(config.getSkillName(), skillName)) {
+            throw new BusinessException(
+                    ErrorCode.CONFLICT,
+                    "Shared AIRegistry Skill cannot be overwritten by this product: " + skillName);
+        }
+        ensureAiRegistrySkillNameAvailable(product, config, skillName);
+        return new AiRegistryUploadBinding(true);
+    }
+
+    private void ensureAiRegistrySkillNameAvailable(
+            Product product, SkillConfig config, String skillName) {
+        Product referencedProduct = findOtherAiRegistrySkillProduct(product, config, skillName);
+        if (referencedProduct != null) {
+            throw new BusinessException(
+                    ErrorCode.CONFLICT,
+                    String.format(
+                            "Skill `%s` is already bound to product `%s` in this AIRegistry"
+                                    + " namespace",
+                            skillName, referencedProduct.getName()));
+        }
+    }
+
+    private Product findOtherAiRegistrySkillProduct(
+            Product product, SkillConfig config, String skillName) {
+        return productRepository.findAllByType(ProductType.AGENT_SKILL).stream()
+                .filter(item -> !Objects.equals(item.getProductId(), product.getProductId()))
+                .filter(item -> matchesAiRegistrySkill(item, config, skillName))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private boolean matchesAiRegistrySkill(Product product, SkillConfig config, String skillName) {
+        if (product.getFeature() == null || product.getFeature().getSkillConfig() == null) {
+            return false;
+        }
+        SkillConfig other = product.getFeature().getSkillConfig();
+        return other.getRegistryType() == SkillRegistryType.AIREGISTRY
+                && Objects.equals(other.getAiRegistryId(), config.getAiRegistryId())
+                && Objects.equals(other.getNamespace(), config.getNamespace())
+                && Objects.equals(other.getSkillName(), skillName);
+    }
+
+    private record AiRegistryUploadBinding(boolean updateLocalSkillName) {}
+
     @Override
     public void deleteSkill(String productId) {
         deleteSkill(productId, false);
@@ -155,19 +236,29 @@ public class SkillServiceImpl implements SkillService {
         SkillConfig config = product.getFeature().getSkillConfig();
         if (config != null && config.getRegistryType() == SkillRegistryType.AIREGISTRY) {
             if (Strings.isNotBlank(config.getSkillName())) {
-                try {
-                    aiRegistrySkillService.deleteSkill(
-                            config.getAiRegistryId(), config.getNamespace(), config.getSkillName());
-                } catch (RuntimeException e) {
-                    if (!ignoreError) {
-                        throw e;
-                    }
-                    log.warn(
-                            "Failed to delete source AIRegistry Skill, ignoring error,"
-                                    + " productId={}, skillName={}",
+                if (findOtherAiRegistrySkillProduct(product, config, config.getSkillName())
+                        != null) {
+                    log.info(
+                            "Skip deleting shared AIRegistry Skill, productId={}, skillName={}",
                             productId,
-                            config.getSkillName(),
-                            e);
+                            config.getSkillName());
+                } else {
+                    try {
+                        aiRegistrySkillService.deleteSkill(
+                                config.getAiRegistryId(),
+                                config.getNamespace(),
+                                config.getSkillName());
+                    } catch (RuntimeException e) {
+                        if (!ignoreError) {
+                            throw e;
+                        }
+                        log.warn(
+                                "Failed to delete source AIRegistry Skill, ignoring error,"
+                                        + " productId={}, skillName={}",
+                                productId,
+                                config.getSkillName(),
+                                e);
+                    }
                 }
                 config.setSkillName(null);
                 config.setVersionInfos(null);

--- a/himarket-server/src/test/java/com/alibaba/himarket/core/skill/SkillZipParserTest.java
+++ b/himarket-server/src/test/java/com/alibaba/himarket/core/skill/SkillZipParserTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.alibaba.himarket.core.skill;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.alibaba.himarket.core.exception.BusinessException;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.Test;
+
+class SkillZipParserTest {
+
+    @Test
+    void parseSkillNameFromSkillMdFrontMatter() throws Exception {
+        byte[] zipBytes =
+                zip("demo-skill/SKILL.md", "---\nname: demo-skill\ndescription: Demo\n---\n\nbody");
+
+        assertEquals("demo-skill", SkillZipParser.parseSkillName(zipBytes));
+    }
+
+    @Test
+    void rejectPackageWithoutSkillMdName() throws Exception {
+        byte[] zipBytes = zip("demo-skill/manifest.json", "{\"name\":\"demo-skill\"}");
+
+        BusinessException exception =
+                assertThrows(
+                        BusinessException.class, () -> SkillZipParser.parseSkillName(zipBytes));
+
+        assertEquals("INVALID_PARAMETER", exception.getCode());
+    }
+
+    private byte[] zip(String entryName, String content) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry(entryName));
+            zos.write(content.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+}

--- a/himarket-server/src/test/java/com/alibaba/himarket/service/impl/SkillServiceImplAiRegistryUploadTest.java
+++ b/himarket-server/src/test/java/com/alibaba/himarket/service/impl/SkillServiceImplAiRegistryUploadTest.java
@@ -20,8 +20,11 @@
 package com.alibaba.himarket.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.alibaba.himarket.core.exception.BusinessException;
@@ -30,10 +33,16 @@ import com.alibaba.himarket.entity.Product;
 import com.alibaba.himarket.repository.ProductRepository;
 import com.alibaba.himarket.service.AiRegistrySkillService;
 import com.alibaba.himarket.service.NacosService;
+import com.alibaba.himarket.support.enums.ProductType;
 import com.alibaba.himarket.support.enums.SkillRegistryType;
 import com.alibaba.himarket.support.product.ProductFeature;
 import com.alibaba.himarket.support.product.SkillConfig;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -46,6 +55,7 @@ class SkillServiceImplAiRegistryUploadTest {
         Product product =
                 Product.builder()
                         .productId("product-a")
+                        .type(ProductType.AGENT_SKILL)
                         .feature(
                                 ProductFeature.builder()
                                         .skillConfig(
@@ -56,13 +66,14 @@ class SkillServiceImplAiRegistryUploadTest {
                                                         .build())
                                         .build())
                         .build();
-        byte[] zipBytes = new byte[] {1, 2, 3};
+        byte[] zipBytes = skillZip("skill-a");
         MultipartFile file = mock(MultipartFile.class);
         when(file.isEmpty()).thenReturn(false);
         when(file.getSize()).thenReturn((long) zipBytes.length);
         when(file.getOriginalFilename()).thenReturn("skill.zip");
         when(file.getBytes()).thenReturn(zipBytes);
         when(productRepository.findByProductId("product-a")).thenReturn(Optional.of(product));
+        when(productRepository.findAllByType(ProductType.AGENT_SKILL)).thenReturn(List.of(product));
         when(aiRegistrySkillService.uploadFromZip(
                         "airegistry-prod", "ns-prod", zipBytes, "skill.zip", true))
                 .thenReturn("skill-a");
@@ -80,7 +91,42 @@ class SkillServiceImplAiRegistryUploadTest {
     }
 
     @Test
-    void aiRegistrySubsequentUploadKeepsExistingProductSkillBinding() throws Exception {
+    void aiRegistryFirstUploadRejectsSkillNameAlreadyBoundByOtherProduct() throws Exception {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        AiRegistrySkillService aiRegistrySkillService = mock(AiRegistrySkillService.class);
+        Product product =
+                aiRegistryProduct("product-a", "Search One", "airegistry-prod", "ns-prod", null);
+        Product otherProduct =
+                aiRegistryProduct(
+                        "product-b", "Search Two", "airegistry-prod", "ns-prod", "web-search");
+        byte[] zipBytes = skillZip("web-search");
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getSize()).thenReturn((long) zipBytes.length);
+        when(file.getOriginalFilename()).thenReturn("skill.zip");
+        when(file.getBytes()).thenReturn(zipBytes);
+        when(productRepository.findByProductId("product-a")).thenReturn(Optional.of(product));
+        when(productRepository.findAllByType(ProductType.AGENT_SKILL))
+                .thenReturn(List.of(product, otherProduct));
+
+        SkillServiceImpl service =
+                new SkillServiceImpl(
+                        mock(NacosService.class),
+                        productRepository,
+                        mock(ContextHolder.class),
+                        aiRegistrySkillService);
+
+        BusinessException exception =
+                assertThrows(
+                        BusinessException.class, () -> service.uploadPackage("product-a", file));
+
+        assertEquals("CONFLICT", exception.getCode());
+        verify(aiRegistrySkillService, never())
+                .uploadFromZip("airegistry-prod", "ns-prod", zipBytes, "skill.zip", true);
+    }
+
+    @Test
+    void aiRegistrySubsequentUploadRejectsDifferentSkillNameBeforeRemoteUpload() throws Exception {
         ProductRepository productRepository = mock(ProductRepository.class);
         AiRegistrySkillService aiRegistrySkillService = mock(AiRegistrySkillService.class);
         Product product =
@@ -98,7 +144,114 @@ class SkillServiceImplAiRegistryUploadTest {
                                                         .build())
                                         .build())
                         .build();
-        byte[] zipBytes = new byte[] {1, 2, 3};
+        byte[] zipBytes = skillZip("aone-authored-code-pr-tracker");
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getSize()).thenReturn((long) zipBytes.length);
+        when(file.getOriginalFilename()).thenReturn("skill.zip");
+        when(file.getBytes()).thenReturn(zipBytes);
+        when(productRepository.findByProductId("product-a")).thenReturn(Optional.of(product));
+
+        SkillServiceImpl service =
+                new SkillServiceImpl(
+                        mock(NacosService.class),
+                        productRepository,
+                        mock(ContextHolder.class),
+                        aiRegistrySkillService);
+
+        BusinessException exception =
+                assertThrows(
+                        BusinessException.class, () -> service.uploadPackage("product-a", file));
+
+        assertEquals("CONFLICT", exception.getCode());
+        assertEquals("web-search", product.getFeature().getSkillConfig().getSkillName());
+        verify(aiRegistrySkillService, never())
+                .uploadFromZip("airegistry-prod", "ns-prod", zipBytes, "skill.zip", true);
+    }
+
+    @Test
+    void aiRegistrySharedBindingRejectsSameSkillNameUploadBeforeRemoteUpload() throws Exception {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        AiRegistrySkillService aiRegistrySkillService = mock(AiRegistrySkillService.class);
+        Product product =
+                aiRegistryProduct(
+                        "product-a", "Search One", "airegistry-prod", "ns-prod", "shared-skill");
+        Product otherProduct =
+                aiRegistryProduct(
+                        "product-b", "Search Two", "airegistry-prod", "ns-prod", "shared-skill");
+        byte[] zipBytes = skillZip("shared-skill");
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getSize()).thenReturn((long) zipBytes.length);
+        when(file.getOriginalFilename()).thenReturn("skill.zip");
+        when(file.getBytes()).thenReturn(zipBytes);
+        when(productRepository.findByProductId("product-a")).thenReturn(Optional.of(product));
+        when(productRepository.findAllByType(ProductType.AGENT_SKILL))
+                .thenReturn(List.of(product, otherProduct));
+
+        SkillServiceImpl service =
+                new SkillServiceImpl(
+                        mock(NacosService.class),
+                        productRepository,
+                        mock(ContextHolder.class),
+                        aiRegistrySkillService);
+
+        BusinessException exception =
+                assertThrows(
+                        BusinessException.class, () -> service.uploadPackage("product-a", file));
+
+        assertEquals("CONFLICT", exception.getCode());
+        verify(aiRegistrySkillService, never())
+                .uploadFromZip("airegistry-prod", "ns-prod", zipBytes, "skill.zip", true);
+    }
+
+    @Test
+    void aiRegistrySharedBindingCanMigrateToUnboundSkillName() throws Exception {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        AiRegistrySkillService aiRegistrySkillService = mock(AiRegistrySkillService.class);
+        Product product =
+                aiRegistryProduct(
+                        "product-a", "Search One", "airegistry-prod", "ns-prod", "shared-skill");
+        Product otherProduct =
+                aiRegistryProduct(
+                        "product-b", "Search Two", "airegistry-prod", "ns-prod", "shared-skill");
+        byte[] zipBytes = skillZip("search-one");
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getSize()).thenReturn((long) zipBytes.length);
+        when(file.getOriginalFilename()).thenReturn("skill.zip");
+        when(file.getBytes()).thenReturn(zipBytes);
+        when(productRepository.findByProductId("product-a")).thenReturn(Optional.of(product));
+        when(productRepository.findAllByType(ProductType.AGENT_SKILL))
+                .thenReturn(List.of(product, otherProduct));
+        when(aiRegistrySkillService.uploadFromZip(
+                        "airegistry-prod", "ns-prod", zipBytes, "skill.zip", true))
+                .thenReturn("search-one");
+
+        SkillServiceImpl service =
+                new SkillServiceImpl(
+                        mock(NacosService.class),
+                        productRepository,
+                        mock(ContextHolder.class),
+                        aiRegistrySkillService);
+
+        service.uploadPackage("product-a", file);
+
+        assertEquals("search-one", product.getFeature().getSkillConfig().getSkillName());
+        assertEquals("shared-skill", otherProduct.getFeature().getSkillConfig().getSkillName());
+        verify(aiRegistrySkillService)
+                .uploadFromZip("airegistry-prod", "ns-prod", zipBytes, "skill.zip", true);
+        verify(productRepository).save(product);
+    }
+
+    @Test
+    void aiRegistrySubsequentUploadAllowsSameSkillName() throws Exception {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        AiRegistrySkillService aiRegistrySkillService = mock(AiRegistrySkillService.class);
+        Product product =
+                aiRegistryProduct(
+                        "product-a", "Web Search", "airegistry-prod", "ns-prod", "web-search");
+        byte[] zipBytes = skillZip("web-search");
         MultipartFile file = mock(MultipartFile.class);
         when(file.isEmpty()).thenReturn(false);
         when(file.getSize()).thenReturn((long) zipBytes.length);
@@ -107,7 +260,7 @@ class SkillServiceImplAiRegistryUploadTest {
         when(productRepository.findByProductId("product-a")).thenReturn(Optional.of(product));
         when(aiRegistrySkillService.uploadFromZip(
                         "airegistry-prod", "ns-prod", zipBytes, "skill.zip", true))
-                .thenReturn("aone-authored-code-pr-tracker");
+                .thenReturn("web-search");
 
         SkillServiceImpl service =
                 new SkillServiceImpl(
@@ -119,7 +272,66 @@ class SkillServiceImplAiRegistryUploadTest {
         service.uploadPackage("product-a", file);
 
         assertEquals("web-search", product.getFeature().getSkillConfig().getSkillName());
-        assertEquals("web-search", product.getName());
+        verify(aiRegistrySkillService)
+                .uploadFromZip("airegistry-prod", "ns-prod", zipBytes, "skill.zip", true);
+    }
+
+    @Test
+    void aiRegistryDeleteKeepsSharedRemoteSkillWhenOtherProductStillReferencesIt() {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        AiRegistrySkillService aiRegistrySkillService = mock(AiRegistrySkillService.class);
+        Product product =
+                aiRegistryProduct(
+                        "product-a", "Search One", "airegistry-prod", "ns-prod", "shared-skill");
+        Product otherProduct =
+                aiRegistryProduct(
+                        "product-b", "Search Two", "airegistry-prod", "ns-prod", "shared-skill");
+        when(productRepository.findByProductId("product-a")).thenReturn(Optional.of(product));
+        when(productRepository.findAllByType(ProductType.AGENT_SKILL))
+                .thenReturn(List.of(product, otherProduct));
+
+        SkillServiceImpl service =
+                new SkillServiceImpl(
+                        mock(NacosService.class),
+                        productRepository,
+                        mock(ContextHolder.class),
+                        aiRegistrySkillService);
+
+        service.deleteSkill("product-a");
+
+        verify(aiRegistrySkillService, never())
+                .deleteSkill("airegistry-prod", "ns-prod", "shared-skill");
+        assertNull(product.getFeature().getSkillConfig().getSkillName());
+        assertEquals("shared-skill", otherProduct.getFeature().getSkillConfig().getSkillName());
+        verify(productRepository).save(product);
+    }
+
+    @Test
+    void aiRegistryDeleteRemovesRemoteSkillWhenNoOtherProductReferencesIt() {
+        ProductRepository productRepository = mock(ProductRepository.class);
+        AiRegistrySkillService aiRegistrySkillService = mock(AiRegistrySkillService.class);
+        Product product =
+                aiRegistryProduct(
+                        "product-a", "Search One", "airegistry-prod", "ns-prod", "unique-skill");
+        Product otherProduct =
+                aiRegistryProduct(
+                        "product-b", "Search Two", "airegistry-prod", "ns-prod", "other-skill");
+        when(productRepository.findByProductId("product-a")).thenReturn(Optional.of(product));
+        when(productRepository.findAllByType(ProductType.AGENT_SKILL))
+                .thenReturn(List.of(product, otherProduct));
+
+        SkillServiceImpl service =
+                new SkillServiceImpl(
+                        mock(NacosService.class),
+                        productRepository,
+                        mock(ContextHolder.class),
+                        aiRegistrySkillService);
+
+        service.deleteSkill("product-a");
+
+        verify(aiRegistrySkillService).deleteSkill("airegistry-prod", "ns-prod", "unique-skill");
+        assertNull(product.getFeature().getSkillConfig().getSkillName());
+        verify(productRepository).save(product);
     }
 
     @Test
@@ -145,5 +357,42 @@ class SkillServiceImplAiRegistryUploadTest {
                         BusinessException.class, () -> service.uploadPackage("product-a", file));
 
         assertEquals("INVALID_REQUEST", exception.getCode());
+    }
+
+    private Product aiRegistryProduct(
+            String productId,
+            String name,
+            String aiRegistryId,
+            String namespace,
+            String skillName) {
+        return Product.builder()
+                .productId(productId)
+                .name(name)
+                .type(ProductType.AGENT_SKILL)
+                .feature(
+                        ProductFeature.builder()
+                                .skillConfig(
+                                        SkillConfig.builder()
+                                                .registryType(SkillRegistryType.AIREGISTRY)
+                                                .aiRegistryId(aiRegistryId)
+                                                .namespace(namespace)
+                                                .skillName(skillName)
+                                                .build())
+                                .build())
+                .build();
+    }
+
+    private byte[] skillZip(String skillName) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry(skillName + "/SKILL.md"));
+            zos.write(
+                    ("---\nname: "
+                                    + skillName
+                                    + "\ndescription: Test skill\n---\n\nTest instructions\n")
+                            .getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
     }
 }

--- a/himarket-web/himarket-admin/src/components/api-product/ApiProductSkillPackage.tsx
+++ b/himarket-web/himarket-admin/src/components/api-product/ApiProductSkillPackage.tsx
@@ -78,6 +78,15 @@ interface ApiProductSkillPackageProps {
   handleRefresh: () => void;
 }
 
+function getApiErrorMessage(error: unknown, fallback: string) {
+  const responseMessage = (error as { response?: { data?: { message?: unknown } } } | undefined)
+    ?.response?.data?.message;
+  if (typeof responseMessage === 'string' && responseMessage.trim()) {
+    return responseMessage.trim();
+  }
+  return error instanceof Error ? error.message : fallback;
+}
+
 export function ApiProductSkillPackage({
   apiProduct,
   handleRefresh,
@@ -962,7 +971,7 @@ export function ApiProductSkillPackage({
       onUploadSuccess?.();
     } catch (error: unknown) {
       message.destroy();
-      const errMsg = error instanceof Error ? error.message : t('product.package.uploadFailed');
+      const errMsg = getApiErrorMessage(error, t('product.package.uploadFailed'));
       message.error(errMsg);
       throw error;
     } finally {


### PR DESCRIPTION
## 📝 Description

- 为 AIRegistry Skill 上传增加包内 `SKILL.md` frontmatter `name` 解析，仅以该字段作为远端 Skill 名称来源
- 限制同一 `airegistryId + namespace + skillName` 只能绑定一个 Himarket Agent Skill 产品，避免多个产品覆盖或误删同一个远端 Skill
- 对历史共享绑定场景增加保护：同名上传拒绝，上传未占用的新 Skill 名称时允许当前产品迁移绑定
- 删除 AIRegistry Skill 时，如果仍有其他产品引用同一远端 Skill，则只清理当前产品本地绑定，不删除远端资源
- 前端上传失败时优先展示后端业务错误信息，便于用户识别 Skill 名称冲突或绑定不匹配问题

## 🔗 Related Issues

N/A

## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] All tests pass locally

验证命令：

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl himarket-server -am test
npm run type-check
git diff --check
```

验证结果：

- 后端测试通过：91 tests, 0 failures, 0 errors
- 前端类型检查通过
- diff 空白检查通过

## 📋 Checklist

- [x] Code quality checks passed
- [x] Code is self-reviewed
- [ ] Comments added for complex code
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or migration guide provided)
- [ ] All CI checks pass

## 📊 Test Coverage

- 新增 `SkillZipParserTest`，覆盖从 `SKILL.md` frontmatter 解析 Skill 名称，以及缺少 `SKILL.md` 名称时失败
- 更新 `SkillServiceImplAiRegistryUploadTest`，覆盖首次上传冲突、后续上传名称不匹配、历史共享绑定迁移、共享删除保护、唯一绑定删除等 AIRegistry Skill 链路

## 📚 Additional Notes

- 本 PR 不包含文档变更
- `SkillZipParser` 只解析 `SKILL.md` YAML frontmatter 中的 `name`，不使用 `manifest.json`、目录名、ZIP 文件名或 Himarket 产品名推断 Skill 名称