### PR TITLE
fix(frontend): restore skill detail tab scrolling

### DIFF
--- a/himarket-web/himarket-frontend/src/components/ProductDetailTabs.test.tsx
+++ b/himarket-web/himarket-frontend/src/components/ProductDetailTabs.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { ProductDetailTabs } from './ProductDetailTabs';
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      disconnect() {}
+      observe() {}
+      unobserve() {}
+    },
+  );
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+afterEach(() => cleanup());
+
+describe('ProductDetailTabs', () => {
+  it('兼容新旧 Ant Design Tabs DOM 并建立填充高度链', () => {
+    const { container } = render(
+      <ProductDetailTabs
+        fillHeight
+        items={[{ children: <div>长内容</div>, key: 'overview', label: '概览' }]}
+      />,
+    );
+
+    const tabs = container.querySelector('.ant-tabs');
+    const panel = container.querySelector('[role="tabpanel"]');
+
+    expect(tabs).toHaveClass('flex', 'min-h-0', 'flex-1', 'flex-col');
+    expect(tabs?.className).toContain('[&_.ant-tabs-content-holder]:overflow-hidden');
+    expect(tabs?.className).toContain('[&_.ant-tabs-body-holder]:overflow-hidden');
+    expect(tabs?.className).toContain('[&_.ant-tabs-body]:h-full');
+    expect(tabs?.className).toContain('[&_.ant-tabs-content]:h-full');
+    expect(tabs?.className).toContain('[&_.ant-tabs-tabpane]:h-full');
+    expect(panel).toHaveClass('h-full', 'min-h-0', 'min-w-0', 'px-5', 'pb-5');
+  });
+
+  it('合并调用方提供的语义类名', () => {
+    const { container } = render(
+      <ProductDetailTabs
+        classNames={{ content: 'custom-content' }}
+        fillHeight
+        items={[{ children: <div>内容</div>, key: 'overview', label: '概览' }]}
+      />,
+    );
+
+    expect(container.querySelector('[role="tabpanel"]')).toHaveClass('custom-content');
+  });
+
+  it('未启用填充高度时保持原有布局', () => {
+    const { container } = render(
+      <ProductDetailTabs items={[{ children: <div>内容</div>, key: 'overview', label: '概览' }]} />,
+    );
+
+    const tabs = container.querySelector('.ant-tabs');
+    const panel = container.querySelector('[role="tabpanel"]');
+
+    expect(tabs).not.toHaveClass('flex', 'min-h-0', 'flex-1', 'flex-col');
+    expect(tabs?.className).not.toContain('[&_.ant-tabs-body-holder]');
+    expect(tabs?.className).not.toContain('[&_.ant-tabs-content-holder]');
+    expect(panel).not.toHaveClass('h-full', 'min-h-0');
+    expect(panel).toHaveClass('min-w-0', 'px-5', 'pb-5');
+  });
+});

--- a/himarket-web/himarket-frontend/src/components/ProductDetailTabs.tsx
+++ b/himarket-web/himarket-frontend/src/components/ProductDetailTabs.tsx
@@ -10,16 +10,20 @@ const PRODUCT_DETAIL_TABS_NAV_CLASS =
   '[&_.ant-tabs-nav]:mb-5 [&_.ant-tabs-nav]:px-5 [&_.ant-tabs-tab]:py-4';
 
 const PRODUCT_DETAIL_TABS_CONTENT_CLASS = 'min-w-0 px-5 pb-5';
+const PRODUCT_DETAIL_TABS_FILL_ROOT_CLASS =
+  'flex min-h-0 flex-1 flex-col [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:flex-1 [&_.ant-tabs-content-holder]:overflow-hidden [&_.ant-tabs-body-holder]:min-h-0 [&_.ant-tabs-body-holder]:flex-1 [&_.ant-tabs-body-holder]:overflow-hidden [&_.ant-tabs-body]:h-full [&_.ant-tabs-content]:h-full [&_.ant-tabs-tabpane]:h-full';
+const PRODUCT_DETAIL_TABS_FILL_CONTENT_CLASS = 'h-full min-h-0';
 
 function classNames(...values: Array<string | undefined>) {
   return values.filter(Boolean).join(' ');
 }
 
-function mergeContentClassName(
+function mergeSemanticClassNames(
   semanticClassNames: TabsProps['classNames'] | undefined,
   contentPadded: boolean,
+  fillHeight: boolean,
 ): TabsProps['classNames'] | undefined {
-  if (!contentPadded) {
+  if (!contentPadded && !fillHeight) {
     return semanticClassNames;
   }
 
@@ -29,14 +33,22 @@ function mergeContentClassName(
 
       return {
         ...resolvedClassNames,
-        content: classNames(PRODUCT_DETAIL_TABS_CONTENT_CLASS, resolvedClassNames.content),
+        content: classNames(
+          contentPadded ? PRODUCT_DETAIL_TABS_CONTENT_CLASS : undefined,
+          fillHeight ? PRODUCT_DETAIL_TABS_FILL_CONTENT_CLASS : undefined,
+          resolvedClassNames.content,
+        ),
       };
     };
   }
 
   return {
     ...semanticClassNames,
-    content: classNames(PRODUCT_DETAIL_TABS_CONTENT_CLASS, semanticClassNames?.content),
+    content: classNames(
+      contentPadded ? PRODUCT_DETAIL_TABS_CONTENT_CLASS : undefined,
+      fillHeight ? PRODUCT_DETAIL_TABS_FILL_CONTENT_CLASS : undefined,
+      semanticClassNames?.content,
+    ),
   };
 }
 
@@ -48,6 +60,7 @@ interface ProductDetailTabLabelProps {
 interface ProductDetailTabsProps extends Omit<TabsProps, 'className' | 'size'> {
   cardClassName?: string;
   contentPadded?: boolean;
+  fillHeight?: boolean;
   style?: CSSProperties;
   tabsClassName?: string;
 }
@@ -65,6 +78,7 @@ export function ProductDetailTabs({
   cardClassName,
   classNames: semanticClassNames,
   contentPadded = true,
+  fillHeight = false,
   style,
   tabsClassName,
   ...tabsProps
@@ -73,8 +87,12 @@ export function ProductDetailTabs({
     <div className={classNames(PRODUCT_DETAIL_TABS_CARD_CLASS, cardClassName)} style={style}>
       <Tabs
         {...tabsProps}
-        className={classNames(PRODUCT_DETAIL_TABS_NAV_CLASS, tabsClassName)}
-        classNames={mergeContentClassName(semanticClassNames, contentPadded)}
+        className={classNames(
+          PRODUCT_DETAIL_TABS_NAV_CLASS,
+          fillHeight ? PRODUCT_DETAIL_TABS_FILL_ROOT_CLASS : undefined,
+          tabsClassName,
+        )}
+        classNames={mergeSemanticClassNames(semanticClassNames, contentPadded, fillHeight)}
         size="large"
       />
     </div>

--- a/himarket-web/himarket-frontend/src/pages/SkillDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/SkillDetail.tsx
@@ -623,6 +623,7 @@ function SkillDetail() {
             <ProductDetailTabs
               activeKey={activeTab}
               cardClassName="flex flex-col"
+              fillHeight
               items={[
                 {
                   children: (
@@ -684,7 +685,6 @@ function SkillDetail() {
               ]}
               onChange={handleTabChange}
               style={{ height: 'calc(100vh - 280px)', minHeight: 520 }}
-              tabsClassName="flex min-h-0 flex-1 flex-col [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:flex-1 [&_.ant-tabs-content-holder]:overflow-hidden [&_.ant-tabs-content]:h-full [&_.ant-tabs-tabpane]:h-full"
             />
           </div>
 

--- a/himarket-web/himarket-frontend/src/pages/WorkerDetail.tsx
+++ b/himarket-web/himarket-frontend/src/pages/WorkerDetail.tsx
@@ -563,6 +563,7 @@ function WorkerDetail() {
             <ProductDetailTabs
               activeKey={activeTab}
               cardClassName="flex flex-col"
+              fillHeight
               items={[
                 {
                   children: (
@@ -625,7 +626,6 @@ function WorkerDetail() {
               ]}
               onChange={handleTabChange}
               style={{ height: 'calc(100vh - 280px)', minHeight: 520 }}
-              tabsClassName="flex min-h-0 flex-1 flex-col [&_.ant-tabs-content-holder]:min-h-0 [&_.ant-tabs-content-holder]:flex-1 [&_.ant-tabs-content-holder]:overflow-hidden [&_.ant-tabs-content]:h-full [&_.ant-tabs-tabpane]:h-full"
             />
           </div>
 


### PR DESCRIPTION
## 📝 Description

- Restore vertical scrolling for the Overview and Files panels on Skill and Worker detail pages.
- Add an opt-in full-height layout to the shared `ProductDetailTabs` component while preserving existing callers.
- Support both the Ant Design 6.1 lockfile DOM and the newer Ant Design 6.5 Tabs DOM.
- Add regression tests for the height chain, semantic class merging, and the default non-full-height layout.

The regression was caused by an Ant Design Tabs DOM change. The detail pages still targeted the old `content-holder` and `tabpane` structure, so the fixed-height card's `overflow-hidden` container clipped long content instead of allowing its inner panels to scroll.

## 🔗 Related Issues

N/A

## ✅ Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI configuration change
- [ ] Other (please describe):

## 🧪 Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests pass locally

Validation performed:

- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- `npm test -- --run` (23 files, 118 tests)
- `npm run build`
- Verified the regression tests with both Ant Design 6.1.0 and 6.5.0

## 📋 Checklist

- [x] Code quality checks passed (run `./scripts/code-check.sh`)
- [x] Code is self-reviewed
- [ ] Comments added for complex code
- [x] Documentation updated (not applicable)
- [x] No breaking changes (or migration guide provided)
- [x] All CI checks pass

## 📊 Test Coverage

- Added three focused tests for the compatible Tabs height chain, caller-provided semantic classes, and unchanged default layout behavior.
- Existing frontend test suite remains green with 118 tests.

## 📚 Additional Notes

- The full-height behavior is enabled only for Skill and Worker detail pages; other `ProductDetailTabs` consumers keep their existing layout.
- No API, data model, or dependency changes are included.
